### PR TITLE
Add layout-based config generator

### DIFF
--- a/firmware/include/config_autogen.h
+++ b/firmware/include/config_autogen.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#define SIDE_ID 0
+#define RUN_COUNT 3
+#define TOTAL_LED_COUNT 1200
+
+static const unsigned int LED_COUNT[RUN_COUNT] = {400, 400, 400};

--- a/firmware/readme.md
+++ b/firmware/readme.md
@@ -1,0 +1,8 @@
+# Firmware
+
+`config_autogen.h` contains constants derived from the layout JSON files.
+Generate it by running the configuration tool:
+
+```
+python tools/gen_config.py --layout left.json
+```

--- a/tools/gen_config.py
+++ b/tools/gen_config.py
@@ -1,0 +1,49 @@
+import argparse
+import json
+from pathlib import Path
+
+
+SIDE_MAPPING = {"left": 0, "right": 1}
+
+
+def generate_header(layout_data: dict) -> str:
+    side_name = layout_data.get("side", "")
+    side_identifier = SIDE_MAPPING.get(side_name.lower())
+    if side_identifier is None:
+        raise ValueError(f"unknown side: {side_name}")
+
+    run_count = len(layout_data.get("runs", []))
+    led_counts = [run.get("led_count", 0) for run in layout_data.get("runs", [])]
+    total_leds = layout_data.get("total_leds", 0)
+
+    header_lines = [
+        "#pragma once",
+        "",
+        f"#define SIDE_ID {side_identifier}",
+        f"#define RUN_COUNT {run_count}",
+        f"#define TOTAL_LED_COUNT {total_leds}",
+        "",
+        "static const unsigned int LED_COUNT[RUN_COUNT] = {" + ", ".join(str(count) for count in led_counts) + "};",
+        "",
+    ]
+    return "\n".join(header_lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate firmware configuration header from layout JSON.")
+    parser.add_argument("--layout", required=True, help="Path to layout JSON file")
+    parser.add_argument("--output", default="firmware/include/config_autogen.h", help="Path to output header file")
+    arguments = parser.parse_args()
+
+    layout_path = Path(arguments.layout)
+    layout_data = json.loads(layout_path.read_text())
+
+    header_text = generate_header(layout_data)
+
+    output_path = Path(arguments.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(header_text)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/readme.md
+++ b/tools/readme.md
@@ -1,0 +1,17 @@
+# Tools
+
+The `gen_config.py` script reads a layout JSON file and writes `firmware/include/config_autogen.h` with constants used by the firmware.
+
+## Usage
+
+Generate configuration from a layout file:
+
+```
+python tools/gen_config.py --layout left.json
+```
+
+Specify a custom output path if needed:
+
+```
+python tools/gen_config.py --layout right.json --output /tmp/config.h
+```

--- a/tools/tests/test_gen_config.py
+++ b/tools/tests/test_gen_config.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+import subprocess
+
+
+def run_and_read(layout: str, tmp_dir: Path) -> str:
+    repo_root = Path(__file__).resolve().parents[2]
+    output_path = tmp_dir / "config_autogen.h"
+    subprocess.run(
+        ["python", "tools/gen_config.py", "--layout", str(repo_root / layout), "--output", str(output_path)],
+        check=True,
+        cwd=repo_root,
+    )
+    return output_path.read_text()
+
+
+def test_left_layout_generates_expected_header(tmp_path):
+    header_text = run_and_read("left.json", tmp_path)
+    assert "#define SIDE_ID 0" in header_text
+    assert "#define RUN_COUNT 3" in header_text
+    assert "#define TOTAL_LED_COUNT 1200" in header_text
+    assert "{400, 400, 400}" in header_text
+
+
+def test_right_layout_generates_expected_header(tmp_path):
+    header_text = run_and_read("right.json", tmp_path)
+    assert "#define SIDE_ID 1" in header_text
+    assert "#define RUN_COUNT 3" in header_text
+    assert "#define TOTAL_LED_COUNT 1500" in header_text
+    assert "{500, 500, 500}" in header_text


### PR DESCRIPTION
## Summary
- generate `config_autogen.h` from layout JSON via `tools/gen_config.py`
- document config generation workflow in firmware and tools readmes
- cover left/right layouts with pytest tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afe0bd67088322a42c96dabb9aaaca