### PR TITLE
Add ESP-IDF firmware skeleton with task stubs

### DIFF
--- a/firmware/CMakeLists.txt
+++ b/firmware/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 3.16)
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(barn-lights-firmware)

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -1,0 +1,26 @@
+# Firmware
+
+This directory contains the ESP-IDF based firmware for the Barn Lights system.
+
+## Architecture
+
+- **main/**: entry point containing `app_main.c`. It creates FreeRTOS tasks:
+  - `network_task` handles networking.
+  - `rx_task` processes inbound messages.
+  - `driver_task` drives the light output.
+  - `status_task` reports status.
+- **components/**: custom components for the firmware (currently empty).
+
+## Building
+
+Ensure ESP-IDF is installed and in your PATH. Then run:
+
+```
+idf.py build
+```
+
+`config_autogen.h` contains constants derived from the layout JSON files and can be regenerated:
+
+```
+python tools/gen_config.py --layout left.json
+```

--- a/firmware/components/README.md
+++ b/firmware/components/README.md
@@ -1,0 +1,3 @@
+# Components
+
+Placeholder for future ESP-IDF components. Add new component directories here with their own CMakeLists and implementation.

--- a/firmware/main/CMakeLists.txt
+++ b/firmware/main/CMakeLists.txt
@@ -1,0 +1,1 @@
+idf_component_register(SRCS "app_main.c" INCLUDE_DIRS "")

--- a/firmware/main/README.md
+++ b/firmware/main/README.md
@@ -1,0 +1,3 @@
+# Main
+
+Application entry point and task startup. `app_main.c` creates stub FreeRTOS tasks for networking, message reception, driver control, and status reporting.

--- a/firmware/main/app_main.c
+++ b/firmware/main/app_main.c
@@ -1,0 +1,38 @@
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+static void network_task(void *task_parameters)
+{
+    for (;;) {
+        vTaskDelay(pdMS_TO_TICKS(1000));
+    }
+}
+
+static void rx_task(void *task_parameters)
+{
+    for (;;) {
+        vTaskDelay(pdMS_TO_TICKS(1000));
+    }
+}
+
+static void driver_task(void *task_parameters)
+{
+    for (;;) {
+        vTaskDelay(pdMS_TO_TICKS(1000));
+    }
+}
+
+static void status_task(void *task_parameters)
+{
+    for (;;) {
+        vTaskDelay(pdMS_TO_TICKS(1000));
+    }
+}
+
+void app_main(void)
+{
+    xTaskCreate(network_task, "network_task", 2048, NULL, 5, NULL);
+    xTaskCreate(rx_task, "rx_task", 2048, NULL, 5, NULL);
+    xTaskCreate(driver_task, "driver_task", 2048, NULL, 5, NULL);
+    xTaskCreate(status_task, "status_task", 2048, NULL, 5, NULL);
+}

--- a/firmware/readme.md
+++ b/firmware/readme.md
@@ -1,8 +1,0 @@
-# Firmware
-
-`config_autogen.h` contains constants derived from the layout JSON files.
-Generate it by running the configuration tool:
-
-```
-python tools/gen_config.py --layout left.json
-```

--- a/firmware/sdkconfig.defaults
+++ b/firmware/sdkconfig.defaults
@@ -1,0 +1,2 @@
+# Default configuration for the Barn Lights firmware
+CONFIG_IDF_TARGET="esp32"


### PR DESCRIPTION
## Summary
- add ESP-IDF project structure under `firmware` with `main`, `components`, `CMakeLists.txt`, and default `sdkconfig`
- implement `app_main.c` that starts stub FreeRTOS tasks for network, rx, driver, and status
- document firmware architecture and build instructions in `firmware/README.md`

## Testing
- `idf.py build` *(fails: command not found – ESP-IDF tooling not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68afe933c4e08322b7c2f52b8ec2a2de