### PR TITLE
Add Ethernet network task

### DIFF
--- a/firmware/include/config_autogen.h
+++ b/firmware/include/config_autogen.h
@@ -5,3 +5,19 @@
 #define TOTAL_LED_COUNT 1200
 
 static const unsigned int LED_COUNT[RUN_COUNT] = {400, 400, 400};
+
+// Static network configuration
+#define STATIC_IP_ADDR0 192
+#define STATIC_IP_ADDR1 168
+#define STATIC_IP_ADDR2 0
+#define STATIC_IP_ADDR3 50
+
+#define STATIC_NETMASK_ADDR0 255
+#define STATIC_NETMASK_ADDR1 255
+#define STATIC_NETMASK_ADDR2 255
+#define STATIC_NETMASK_ADDR3 0
+
+#define STATIC_GW_ADDR0 192
+#define STATIC_GW_ADDR1 168
+#define STATIC_GW_ADDR2 0
+#define STATIC_GW_ADDR3 1

--- a/firmware/main/CMakeLists.txt
+++ b/firmware/main/CMakeLists.txt
@@ -1,1 +1,1 @@
-idf_component_register(SRCS "app_main.c" INCLUDE_DIRS "")
+idf_component_register(SRCS "app_main.c" "net_task.c" INCLUDE_DIRS "")

--- a/firmware/main/README.md
+++ b/firmware/main/README.md
@@ -1,3 +1,3 @@
 # Main
 
-Application entry point and task startup. `app_main.c` creates stub FreeRTOS tasks for networking, message reception, driver control, and status reporting.
+Application entry point and task startup. `app_main.c` creates FreeRTOS tasks for networking, message reception, driver control, and status reporting. The networking task is implemented in `net_task.c` and raises `NETWORK_READY_BIT` once the Ethernet interface is initialised.

--- a/firmware/main/app_main.c
+++ b/firmware/main/app_main.c
@@ -1,12 +1,6 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-
-static void network_task(void *task_parameters)
-{
-    for (;;) {
-        vTaskDelay(pdMS_TO_TICKS(1000));
-    }
-}
+#include "net_task.h"
 
 static void rx_task(void *task_parameters)
 {
@@ -31,7 +25,7 @@ static void status_task(void *task_parameters)
 
 void app_main(void)
 {
-    xTaskCreate(network_task, "network_task", 2048, NULL, 5, NULL);
+    net_task_start();
     xTaskCreate(rx_task, "rx_task", 2048, NULL, 5, NULL);
     xTaskCreate(driver_task, "driver_task", 2048, NULL, 5, NULL);
     xTaskCreate(status_task, "status_task", 2048, NULL, 5, NULL);

--- a/firmware/main/net_task.c
+++ b/firmware/main/net_task.c
@@ -1,0 +1,119 @@
+#include "net_task.h"
+
+#include "freertos/task.h"
+#include "esp_event.h"
+#include "esp_eth.h"
+#include "esp_netif.h"
+#include "esp_log.h"
+#include "config_autogen.h"
+
+// Compile-time checks for static IP configuration
+#ifndef STATIC_IP_ADDR0
+#error "STATIC_IP_ADDR0 not defined"
+#endif
+#ifndef STATIC_IP_ADDR1
+#error "STATIC_IP_ADDR1 not defined"
+#endif
+#ifndef STATIC_IP_ADDR2
+#error "STATIC_IP_ADDR2 not defined"
+#endif
+#ifndef STATIC_IP_ADDR3
+#error "STATIC_IP_ADDR3 not defined"
+#endif
+#ifndef STATIC_NETMASK_ADDR0
+#error "STATIC_NETMASK_ADDR0 not defined"
+#endif
+#ifndef STATIC_NETMASK_ADDR1
+#error "STATIC_NETMASK_ADDR1 not defined"
+#endif
+#ifndef STATIC_NETMASK_ADDR2
+#error "STATIC_NETMASK_ADDR2 not defined"
+#endif
+#ifndef STATIC_NETMASK_ADDR3
+#error "STATIC_NETMASK_ADDR3 not defined"
+#endif
+#ifndef STATIC_GW_ADDR0
+#error "STATIC_GW_ADDR0 not defined"
+#endif
+#ifndef STATIC_GW_ADDR1
+#error "STATIC_GW_ADDR1 not defined"
+#endif
+#ifndef STATIC_GW_ADDR2
+#error "STATIC_GW_ADDR2 not defined"
+#endif
+#ifndef STATIC_GW_ADDR3
+#error "STATIC_GW_ADDR3 not defined"
+#endif
+
+_Static_assert(STATIC_IP_ADDR0 <= 255 && STATIC_IP_ADDR1 <= 255 &&
+               STATIC_IP_ADDR2 <= 255 && STATIC_IP_ADDR3 <= 255,
+               "Static IP octets must be in range 0-255");
+_Static_assert(STATIC_NETMASK_ADDR0 <= 255 && STATIC_NETMASK_ADDR1 <= 255 &&
+               STATIC_NETMASK_ADDR2 <= 255 && STATIC_NETMASK_ADDR3 <= 255,
+               "Netmask octets must be in range 0-255");
+_Static_assert(STATIC_GW_ADDR0 <= 255 && STATIC_GW_ADDR1 <= 255 &&
+               STATIC_GW_ADDR2 <= 255 && STATIC_GW_ADDR3 <= 255,
+               "Gateway octets must be in range 0-255");
+
+// RMII pin configuration
+#define RMII_MDC_GPIO 23
+#define RMII_MDIO_GPIO 18
+#define RMII_REF_CLK_GPIO 0
+
+_Static_assert(RMII_MDC_GPIO >= 0 && RMII_MDC_GPIO <= 39, "RMII_MDC_GPIO out of range");
+_Static_assert(RMII_MDIO_GPIO >= 0 && RMII_MDIO_GPIO <= 39, "RMII_MDIO_GPIO out of range");
+_Static_assert(RMII_REF_CLK_GPIO >= 0 && RMII_REF_CLK_GPIO <= 39, "RMII_REF_CLK_GPIO out of range");
+
+static EventGroupHandle_t network_event_group;
+static const char *LOG_TAG = "net_task";
+
+static void network_task(void *param)
+{
+    ESP_ERROR_CHECK(esp_netif_init());
+    ESP_ERROR_CHECK(esp_event_loop_create_default());
+
+    esp_netif_config_t netif_config = ESP_NETIF_DEFAULT_ETH();
+    esp_netif_t *netif = esp_netif_new(&netif_config);
+
+    eth_mac_config_t mac_config = ETH_MAC_DEFAULT_CONFIG();
+    eth_phy_config_t phy_config = ETH_PHY_DEFAULT_CONFIG();
+    phy_config.phy_addr = 0;
+    phy_config.reset_gpio_num = -1;
+
+    eth_esp32_emac_config_t emac_config = ETH_ESP32_EMAC_DEFAULT_CONFIG();
+    emac_config.smi_mdc_gpio_num = RMII_MDC_GPIO;
+    emac_config.smi_mdio_gpio_num = RMII_MDIO_GPIO;
+    emac_config.clock_config.rmii.clock_mode = EMAC_CLK_OUT;
+    emac_config.clock_config.rmii.clock_gpio = RMII_REF_CLK_GPIO;
+
+    esp_eth_mac_t *mac = esp_eth_mac_new_esp32(&mac_config, &emac_config);
+    esp_eth_phy_t *phy = esp_eth_phy_new_lan8720(&phy_config);
+
+    esp_eth_config_t eth_config = ETH_DEFAULT_CONFIG(mac, phy);
+    esp_eth_handle_t eth_handle = NULL;
+    ESP_ERROR_CHECK(esp_eth_driver_install(&eth_config, &eth_handle));
+    ESP_ERROR_CHECK(esp_netif_attach(netif, esp_eth_new_netif_glue(eth_handle)));
+
+    esp_netif_ip_info_t ip_info;
+    IP4_ADDR(&ip_info.ip, STATIC_IP_ADDR0, STATIC_IP_ADDR1, STATIC_IP_ADDR2, STATIC_IP_ADDR3);
+    IP4_ADDR(&ip_info.netmask, STATIC_NETMASK_ADDR0, STATIC_NETMASK_ADDR1, STATIC_NETMASK_ADDR2, STATIC_NETMASK_ADDR3);
+    IP4_ADDR(&ip_info.gw, STATIC_GW_ADDR0, STATIC_GW_ADDR1, STATIC_GW_ADDR2, STATIC_GW_ADDR3);
+    ESP_ERROR_CHECK(esp_netif_dhcpc_stop(netif));
+    ESP_ERROR_CHECK(esp_netif_set_ip_info(netif, &ip_info));
+
+    ESP_ERROR_CHECK(esp_eth_start(eth_handle));
+    xEventGroupSetBits(network_event_group, NETWORK_READY_BIT);
+    ESP_LOGI(LOG_TAG, "Network ready");
+
+    for (;;) {
+        vTaskDelay(pdMS_TO_TICKS(1000));
+    }
+}
+
+EventGroupHandle_t net_task_start(void)
+{
+    network_event_group = xEventGroupCreate();
+    xTaskCreate(network_task, "net_task", 4096, NULL, 5, NULL);
+    return network_event_group;
+}
+

--- a/firmware/main/net_task.h
+++ b/firmware/main/net_task.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/event_groups.h"
+
+#define NETWORK_READY_BIT BIT0
+
+// Starts the network task and returns the event group used for signalling.
+EventGroupHandle_t net_task_start(void);
+

--- a/firmware/main/net_task.md
+++ b/firmware/main/net_task.md
@@ -1,0 +1,7 @@
+# Network Task
+
+Initialises the ESP32 Ethernet interface using the LAN8720 PHY. The task configures the RMII pins, installs the EMAC driver and assigns a static IP address using values generated in `config_autogen.h`.
+
+Once the interface is started, the task sets `NETWORK_READY_BIT` on its event group to signal that the network stack is ready for use.
+
+Compile-time assertions validate the presence and range of the IP configuration macros and RMII pin selections. Builds will fail if the configuration is missing or out of range, catching misconfiguration early.


### PR DESCRIPTION
## Summary
- initialize Ethernet via new `net_task` using LAN8720 and RMII pins
- apply static IP configuration from `config_autogen.h`
- expose readiness through an event group and document behavior

## Testing
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b03c39d72c83228c755cb63218ee2e