### PR TITLE
Add unit test for network task

### DIFF
--- a/firmware/main/CMakeLists.txt
+++ b/firmware/main/CMakeLists.txt
@@ -1,1 +1,5 @@
 idf_component_register(SRCS "app_main.c" "net_task.c" INCLUDE_DIRS "")
+
+unity_add_test(NAME test_net_task
+               SOURCES "test/test_net_task.c"
+               REQUIRES unity cmock esp_netif esp_eth esp_event)

--- a/firmware/main/README.md
+++ b/firmware/main/README.md
@@ -1,3 +1,5 @@
 # Main
 
 Application entry point and task startup. `app_main.c` creates FreeRTOS tasks for networking, message reception, driver control, and status reporting. The networking task is implemented in `net_task.c` and raises `NETWORK_READY_BIT` once the Ethernet interface is initialised.
+
+Unit tests reside in `test/test_net_task.c` and can be run with `idf.py test`.

--- a/firmware/main/test/test_net_task.c
+++ b/firmware/main/test/test_net_task.c
@@ -1,0 +1,47 @@
+#include "unity.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/event_groups.h"
+#include "mock_esp_netif.h"
+#include "mock_esp_eth.h"
+#include "mock_esp_event.h"
+
+#define ESP_LOGI(tag, fmt, ...)
+#define vTaskDelay(...) return
+#define IP4_ADDR(addr, a,b,c,d)
+
+#define static
+#include "net_task.c"
+#undef static
+#undef vTaskDelay
+#undef ESP_LOGI
+#undef IP4_ADDR
+
+void setUp(void)
+{
+    network_event_group = xEventGroupCreate();
+}
+
+void tearDown(void)
+{
+    vEventGroupDelete(network_event_group);
+}
+
+void test_network_task_sets_ready_bit(void)
+{
+    esp_netif_init_ExpectAndReturn(ESP_OK);
+    esp_event_loop_create_default_ExpectAndReturn(ESP_OK);
+    esp_netif_new_ExpectAnyArgsAndReturn((esp_netif_t *)1);
+    esp_eth_mac_new_esp32_ExpectAnyArgsAndReturn((esp_eth_mac_t *)1);
+    esp_eth_phy_new_lan8720_ExpectAnyArgsAndReturn((esp_eth_phy_t *)1);
+    esp_eth_driver_install_ExpectAnyArgsAndReturn(ESP_OK);
+    esp_netif_attach_ExpectAnyArgsAndReturn(ESP_OK);
+    esp_eth_new_netif_glue_ExpectAnyArgsAndReturn((void *)1);
+    esp_netif_dhcpc_stop_ExpectAnyArgsAndReturn(ESP_OK);
+    esp_netif_set_ip_info_ExpectAnyArgsAndReturn(ESP_OK);
+    esp_eth_start_ExpectAnyArgsAndReturn(ESP_OK);
+
+    network_task(NULL);
+
+    EventBits_t bits = xEventGroupGetBits(network_event_group);
+    TEST_ASSERT_TRUE(bits & NETWORK_READY_BIT);
+}


### PR DESCRIPTION
## Summary
- add Unity test covering network task initialization with esp_netif/esp_eth mocks
- register test in main component's CMakeLists
- document new test

## Testing
- `idf.py test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b041bc0e188322b3b4b87912870fe8