### PR TITLE
Implement RMT driver with blackout and timing checks

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -7,7 +7,7 @@ This directory contains the ESP-IDF based firmware for the Barn Lights system.
 - **main/**: entry point containing `app_main.c`. It creates FreeRTOS tasks:
   - `network_task` handles networking.
   - `rx_task` processes inbound messages.
-  - `driver_task` drives the light output.
+  - `driver_task` drives the light output with one RMT channel per run, triggering channels simultaneously and enforcing a one second blackout at boot.
   - `status_task` reports status.
 - **components/**: custom components for the firmware (currently empty).
 

--- a/firmware/main/CMakeLists.txt
+++ b/firmware/main/CMakeLists.txt
@@ -1,4 +1,4 @@
-idf_component_register(SRCS "app_main.c" "net_task.c" "rx_task.c" INCLUDE_DIRS "")
+idf_component_register(SRCS "app_main.c" "net_task.c" "rx_task.c" "driver_task.c" INCLUDE_DIRS "")
 
 unity_add_test(NAME test_net_task
                SOURCES "test/test_net_task.c"

--- a/firmware/main/README.md
+++ b/firmware/main/README.md
@@ -3,6 +3,7 @@
 Application entry point and task startup. `app_main.c` creates FreeRTOS tasks for networking, UDP frame reception, driver control, and status reporting.
 
 - `net_task.c` initialises Ethernet and raises `NETWORK_READY_BIT` once the interface is ready.
-- `rx_task.c` opens UDP sockets on `PORT_BASE + run_index`, validates packet length, converts RGB bytes to GRB, and assembles frame buffers keyed by `frame_id`, keeping only the current and next frames.
+- `rx_task.c` opens UDP sockets on `PORT_BASE + run_index`, validates packet length, and assembles frame buffers keyed by `frame_id`, keeping only the current and next frames.
+- `driver_task.c` configures one RMT channel per run and triggers them simultaneously. On boot it enforces a one second blackout before displaying the first complete frame, swapping buffers when a new frame arrives and converting RGB bytes to GRB during encoding. Compile-time checks verify RMT timing.
 
 Unit tests reside in `test/test_net_task.c` and can be run with `idf.py test`.

--- a/firmware/main/app_main.c
+++ b/firmware/main/app_main.c
@@ -2,13 +2,7 @@
 #include "freertos/task.h"
 #include "net_task.h"
 #include "rx_task.h"
-
-static void driver_task(void *task_parameters)
-{
-    for (;;) {
-        vTaskDelay(pdMS_TO_TICKS(1000));
-    }
-}
+#include "driver_task.h"
 
 static void status_task(void *task_parameters)
 {
@@ -21,6 +15,6 @@ void app_main(void)
 {
     net_task_start();
     rx_task_start();
-    xTaskCreate(driver_task, "driver_task", 2048, NULL, 5, NULL);
+    driver_task_start();
     xTaskCreate(status_task, "status_task", 2048, NULL, 5, NULL);
 }

--- a/firmware/main/driver_task.c
+++ b/firmware/main/driver_task.c
@@ -1,0 +1,154 @@
+#include "driver_task.h"
+
+#include "config_autogen.h"
+#include "rx_task.h"
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "driver/rmt.h"
+#include "esp_log.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#define RMT_CLK_DIV 2
+#define RMT_TICKS_PER_BIT (80000000 / RMT_CLK_DIV / 800000)
+_Static_assert(RMT_TICKS_PER_BIT == 50, "Unexpected RMT bit timing");
+
+#define RMT_T0H_TICKS 16
+#define RMT_T0L_TICKS (RMT_TICKS_PER_BIT - RMT_T0H_TICKS)
+#define RMT_T1H_TICKS 32
+#define RMT_T1L_TICKS (RMT_TICKS_PER_BIT - RMT_T1H_TICKS)
+_Static_assert(RMT_T0H_TICKS + RMT_T0L_TICKS == RMT_TICKS_PER_BIT, "T0 timing");
+_Static_assert(RMT_T1H_TICKS + RMT_T1L_TICKS == RMT_TICKS_PER_BIT, "T1 timing");
+
+static const gpio_num_t RUN_GPIO[RUN_COUNT] = {12, 13, 14};
+
+_Static_assert(RUN_COUNT <= RMT_CHANNEL_MAX, "Too many runs for available RMT channels");
+_Static_assert(RUN_GPIO[0] >= 0 && RUN_GPIO[0] <= 39, "RUN_GPIO[0] out of range");
+#if RUN_COUNT > 1
+_Static_assert(RUN_GPIO[1] >= 0 && RUN_GPIO[1] <= 39, "RUN_GPIO[1] out of range");
+#endif
+#if RUN_COUNT > 2
+_Static_assert(RUN_GPIO[2] >= 0 && RUN_GPIO[2] <= 39, "RUN_GPIO[2] out of range");
+#endif
+
+static rmt_item32_t *rmt_items[RUN_COUNT];
+static size_t rmt_item_count[RUN_COUNT];
+
+static inline void encode_run(unsigned int run_index, const uint8_t *rgb_data)
+{
+    rmt_item32_t *items = rmt_items[run_index];
+    size_t item_index = 0;
+    for (unsigned int led_index = 0; led_index < LED_COUNT[run_index]; ++led_index) {
+        uint8_t red = rgb_data[led_index * 3];
+        uint8_t green = rgb_data[led_index * 3 + 1];
+        uint8_t blue = rgb_data[led_index * 3 + 2];
+        uint8_t grb[3] = {green, red, blue};
+        for (int color = 0; color < 3; ++color) {
+            uint8_t value = grb[color];
+            for (int bit = 7; bit >= 0; --bit) {
+                bool bit_set = value & (1 << bit);
+                items[item_index].duration0 = bit_set ? RMT_T1H_TICKS : RMT_T0H_TICKS;
+                items[item_index].level0 = 1;
+                items[item_index].duration1 = bit_set ? RMT_T1L_TICKS : RMT_T0L_TICKS;
+                items[item_index].level1 = 0;
+                ++item_index;
+            }
+        }
+    }
+}
+
+static bool frame_is_newer(uint32_t a, uint32_t b)
+{
+    return (int32_t)(a - b) > 0;
+}
+
+static void send_frame(int slot_index)
+{
+    for (unsigned int run = 0; run < RUN_COUNT; ++run) {
+        const uint8_t *buffer = rx_task_get_run_buffer(slot_index, run);
+        encode_run(run, buffer);
+        rmt_fill_tx_items(run, rmt_items[run], rmt_item_count[run], 0);
+    }
+    for (unsigned int run = 0; run < RUN_COUNT; ++run) {
+        rmt_tx_start(run, true);
+    }
+    for (unsigned int run = 0; run < RUN_COUNT; ++run) {
+        rmt_wait_tx_done(run, pdMS_TO_TICKS(1));
+    }
+}
+
+static void send_black(void)
+{
+    for (unsigned int run = 0; run < RUN_COUNT; ++run) {
+        memset(rmt_items[run], 0, sizeof(rmt_item32_t) * rmt_item_count[run]);
+        rmt_fill_tx_items(run, rmt_items[run], rmt_item_count[run], 0);
+    }
+    for (unsigned int run = 0; run < RUN_COUNT; ++run) {
+        rmt_tx_start(run, true);
+    }
+    for (unsigned int run = 0; run < RUN_COUNT; ++run) {
+        rmt_wait_tx_done(run, pdMS_TO_TICKS(1));
+    }
+}
+
+static void driver_task(void *arg)
+{
+    for (unsigned int run = 0; run < RUN_COUNT; ++run) {
+        rmt_config_t config = RMT_DEFAULT_CONFIG_TX(RUN_GPIO[run], run);
+        config.clk_div = RMT_CLK_DIV;
+        rmt_config(&config);
+        rmt_driver_install(run, 0, 0);
+        rmt_item_count[run] = LED_COUNT[run] * 24;
+        rmt_items[run] = (rmt_item32_t *)malloc(sizeof(rmt_item32_t) * rmt_item_count[run]);
+        memset(rmt_items[run], 0, sizeof(rmt_item32_t) * rmt_item_count[run]);
+    }
+
+    send_black();
+
+    TickType_t start_tick = xTaskGetTickCount();
+    uint32_t last_frame_id = 0;
+    bool first_frame_sent = false;
+
+    for (;;) {
+        int selected_slot = -1;
+        uint32_t selected_id = last_frame_id;
+        for (int slot = 0; slot < 2; ++slot) {
+            uint32_t frame_id = rx_task_get_frame_id(slot);
+            if (frame_is_newer(frame_id, selected_id)) {
+                bool complete = true;
+                for (unsigned int run = 0; run < RUN_COUNT; ++run) {
+                    if (!rx_task_run_received(slot, run)) {
+                        complete = false;
+                        break;
+                    }
+                }
+                if (complete) {
+                    selected_slot = slot;
+                    selected_id = frame_id;
+                }
+            }
+        }
+
+        TickType_t now = xTaskGetTickCount();
+        bool blackout_elapsed = (now - start_tick) >= pdMS_TO_TICKS(1000);
+        if (selected_slot >= 0 && blackout_elapsed) {
+            send_frame(selected_slot);
+            last_frame_id = selected_id;
+            first_frame_sent = true;
+        }
+
+        if (!first_frame_sent && blackout_elapsed && selected_slot < 0) {
+            send_black();
+        }
+
+        vTaskDelay(pdMS_TO_TICKS(1));
+    }
+}
+
+void driver_task_start(void)
+{
+    xTaskCreate(driver_task, "driver_task", 4096, NULL, 5, NULL);
+}
+

--- a/firmware/main/driver_task.h
+++ b/firmware/main/driver_task.h
@@ -1,0 +1,4 @@
+#pragma once
+
+void driver_task_start(void);
+

--- a/firmware/main/rx_task.c
+++ b/firmware/main/rx_task.c
@@ -137,7 +137,6 @@ void rx_task_start(void) {
 #endif
 }
 
-#ifdef UNIT_TEST
 uint32_t rx_task_get_frame_id(int slot_index) {
     if (slot_index < 0 || slot_index > 1) {
         return 0;
@@ -158,5 +157,4 @@ bool rx_task_run_received(int slot_index, unsigned int run_index) {
     }
     return frame_slots[slot_index].run_received[run_index];
 }
-#endif
 

--- a/firmware/main/rx_task.h
+++ b/firmware/main/rx_task.h
@@ -7,9 +7,7 @@
 void rx_task_start(void);
 void rx_task_process_packet(unsigned int run_index, const uint8_t *data, size_t length);
 
-#ifdef UNIT_TEST
 uint32_t rx_task_get_frame_id(int slot_index);
 const uint8_t *rx_task_get_run_buffer(int slot_index, unsigned int run_index);
 bool rx_task_run_received(int slot_index, unsigned int run_index);
-#endif
 


### PR DESCRIPTION
## Summary
- add dedicated `driver_task` using one RMT channel per run and starting channels together
- enforce a one second blackout on boot and swap buffers only on complete frames
- include compile-time timing and pin-range checks; document driver task architecture

## Testing
- `idf.py test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b09ebcd6c08322812f54ee9400a6e3