### PR TITLE
Add heartbeat status task

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -8,7 +8,7 @@ This directory contains the ESP-IDF based firmware for the Barn Lights system.
   - `network_task` handles networking.
   - `rx_task` processes inbound messages.
   - `driver_task` drives the light output with one RMT channel per run, triggering channels simultaneously and enforcing a one second blackout at boot.
-  - `status_task` reports status.
+  - `status_task` emits a heartbeat JSON every second to `SENDER_IP:STATUS_PORT` containing runtime counters.
 - **components/**: custom components for the firmware (currently empty).
 
 ## Building

--- a/firmware/main/CMakeLists.txt
+++ b/firmware/main/CMakeLists.txt
@@ -1,4 +1,4 @@
-idf_component_register(SRCS "app_main.c" "net_task.c" "rx_task.c" "driver_task.c" INCLUDE_DIRS "")
+idf_component_register(SRCS "app_main.c" "net_task.c" "rx_task.c" "driver_task.c" "status_task.c" INCLUDE_DIRS "")
 
 unity_add_test(NAME test_net_task
                SOURCES "test/test_net_task.c"

--- a/firmware/main/README.md
+++ b/firmware/main/README.md
@@ -5,5 +5,6 @@ Application entry point and task startup. `app_main.c` creates FreeRTOS tasks fo
 - `net_task.c` initialises Ethernet and raises `NETWORK_READY_BIT` once the interface is ready.
 - `rx_task.c` opens UDP sockets on `PORT_BASE + run_index`, validates packet length, and assembles frame buffers keyed by `frame_id`, keeping only the current and next frames.
 - `driver_task.c` configures one RMT channel per run and triggers them simultaneously. On boot it enforces a one second blackout before displaying the first complete frame, swapping buffers when a new frame arrives and converting RGB bytes to GRB during encoding. Compile-time checks verify RMT timing.
+- `status_task.c` sends a heartbeat JSON every second to `SENDER_IP:STATUS_PORT`, reporting counters since the previous heartbeat.
 
 Unit tests reside in `test/test_net_task.c` and can be run with `idf.py test`.

--- a/firmware/main/app_main.c
+++ b/firmware/main/app_main.c
@@ -1,20 +1,12 @@
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
 #include "net_task.h"
 #include "rx_task.h"
 #include "driver_task.h"
-
-static void status_task(void *task_parameters)
-{
-    for (;;) {
-        vTaskDelay(pdMS_TO_TICKS(1000));
-    }
-}
+#include "status_task.h"
 
 void app_main(void)
 {
     net_task_start();
     rx_task_start();
     driver_task_start();
-    xTaskCreate(status_task, "status_task", 2048, NULL, 5, NULL);
+    status_task_start();
 }

--- a/firmware/main/status_task.c
+++ b/firmware/main/status_task.c
@@ -1,0 +1,91 @@
+#include "status_task.h"
+#include "config_autogen.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#ifndef SENDER_IP_ADDR0
+#define SENDER_IP_ADDR0 10
+#define SENDER_IP_ADDR1 10
+#define SENDER_IP_ADDR2 0
+#define SENDER_IP_ADDR3 1
+#endif
+
+#ifndef STATUS_PORT
+#define STATUS_PORT 49700
+#endif
+
+#if SIDE_ID == 0
+#define SIDE_ID_STR "LEFT"
+#else
+#define SIDE_ID_STR "RIGHT"
+#endif
+
+static uint32_t rx_frames_count;
+static uint32_t complete_count;
+static uint32_t applied_count;
+static uint32_t dropped_count;
+
+void status_task_increment_rx_frames(void) { rx_frames_count++; }
+void status_task_increment_complete(void) { complete_count++; }
+void status_task_increment_applied(void) { applied_count++; }
+void status_task_increment_drops(void) { dropped_count++; }
+void status_task_reset_counters(void) {
+    rx_frames_count = 0;
+    complete_count = 0;
+    applied_count = 0;
+    dropped_count = 0;
+}
+
+size_t status_task_format_json(char *buffer, size_t buffer_len, uint32_t uptime_ms, bool link) {
+    char ip_str[16];
+    snprintf(ip_str, sizeof(ip_str), "%u.%u.%u.%u", STATIC_IP_ADDR0, STATIC_IP_ADDR1, STATIC_IP_ADDR2, STATIC_IP_ADDR3);
+    size_t offset = 0;
+    offset += snprintf(buffer + offset, buffer_len - offset,
+                       "{\"id\":\"%s\",\"ip\":\"%s\",\"uptime_ms\":%u,\"link\":%s,\"runs\":%u,\"leds\":[",
+                       SIDE_ID_STR, ip_str, uptime_ms, link ? "true" : "false", RUN_COUNT);
+    for (unsigned int i = 0; i < RUN_COUNT; ++i) {
+        offset += snprintf(buffer + offset, buffer_len - offset, "%u", LED_COUNT[i]);
+        if (i + 1 < RUN_COUNT) {
+            offset += snprintf(buffer + offset, buffer_len - offset, ",");
+        }
+    }
+    offset += snprintf(buffer + offset, buffer_len - offset,
+                       "],\"rx_frames\":%u,\"complete\":%u,\"applied\":%u,\"dropped_frames\":%u,\"errors\":[]}",
+                       rx_frames_count, complete_count, applied_count, dropped_count);
+    return offset;
+}
+
+#ifndef UNIT_TEST
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "lwip/inet.h"
+#include "lwip/sockets.h"
+#include "esp_timer.h"
+
+static void status_task(void *param) {
+    int sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    struct sockaddr_in dest = {
+        .sin_family = AF_INET,
+        .sin_port = htons(STATUS_PORT),
+        .sin_addr.s_addr = htonl(((uint32_t)SENDER_IP_ADDR0 << 24) |
+                                 ((uint32_t)SENDER_IP_ADDR1 << 16) |
+                                 ((uint32_t)SENDER_IP_ADDR2 << 8) |
+                                 (uint32_t)SENDER_IP_ADDR3),
+    };
+    char json[256];
+    for (;;) {
+        uint32_t uptime_ms = (uint32_t)(esp_timer_get_time() / 1000);
+        status_task_format_json(json, sizeof(json), uptime_ms, true);
+        sendto(sock, json, strlen(json), 0, (struct sockaddr *)&dest, sizeof(dest));
+        status_task_reset_counters();
+        vTaskDelay(pdMS_TO_TICKS(1000));
+    }
+}
+
+void status_task_start(void) {
+    xTaskCreate(status_task, "status_task", 4096, NULL, 5, NULL);
+}
+#else
+void status_task_start(void) {}
+#endif

--- a/firmware/main/status_task.h
+++ b/firmware/main/status_task.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+void status_task_start(void);
+
+void status_task_increment_rx_frames(void);
+void status_task_increment_complete(void);
+void status_task_increment_applied(void);
+void status_task_increment_drops(void);
+void status_task_reset_counters(void);
+
+size_t status_task_format_json(char *buffer, size_t buffer_len, uint32_t uptime_ms, bool link);

--- a/firmware/test/CMakeLists.txt
+++ b/firmware/test/CMakeLists.txt
@@ -24,3 +24,12 @@ target_include_directories(test_rx_task PRIVATE ../include ../main)
 target_compile_definitions(test_rx_task PRIVATE UNIT_TEST)
 target_link_libraries(test_rx_task unity)
 
+add_executable(test_status_task
+    test_status_task.c
+    ../main/status_task.c
+)
+
+target_include_directories(test_status_task PRIVATE ../include ../main)
+target_compile_definitions(test_status_task PRIVATE UNIT_TEST)
+target_link_libraries(test_status_task unity)
+

--- a/firmware/test/README.md
+++ b/firmware/test/README.md
@@ -10,5 +10,6 @@ From the repository root:
 cmake -S firmware/test -B firmware/test/build
 cmake --build firmware/test/build
 ./firmware/test/build/test_rx_task
+./firmware/test/build/test_status_task
 ```
 

--- a/firmware/test/test_status_task.c
+++ b/firmware/test/test_status_task.c
@@ -1,0 +1,26 @@
+#include "unity.h"
+#include "status_task.h"
+#include "config_autogen.h"
+#include <string.h>
+
+void setUp(void) { status_task_reset_counters(); }
+void tearDown(void) {}
+
+void test_format_json(void) {
+    status_task_increment_rx_frames();
+    status_task_increment_complete();
+    status_task_increment_applied();
+    status_task_increment_drops();
+    char buf[256];
+    size_t len = status_task_format_json(buf, sizeof(buf), 123, true);
+    const char *expected =
+        "{\"id\":\"LEFT\",\"ip\":\"192.168.0.50\",\"uptime_ms\":123,\"link\":true,\"runs\":3,\"leds\":[400,400,400],\"rx_frames\":1,\"complete\":1,\"applied\":1,\"dropped_frames\":1,\"errors\":[]}";
+    TEST_ASSERT_EQUAL(strlen(expected), len);
+    TEST_ASSERT_EQUAL_STRING(expected, buf);
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_format_json);
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary
- send heartbeat JSON every second with runtime counters
- expose counter increment helpers for other tasks
- cover heartbeat format with host-side unit tests

## Testing
- `cmake -S firmware/test -B firmware/test/build`
- `cmake --build firmware/test/build`
- `./firmware/test/build/test_rx_task`
- `./firmware/test/build/test_status_task`


------
https://chatgpt.com/codex/tasks/task_e_68b0ffb502148322ab2b08cc080fa3fa