### PR TITLE
Remove firmware unit tests from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,3 @@ jobs:
       - name: Run host tests
         run: ./firmware/test/build/test_rx_task
 
-      - name: Run firmware unit tests
-        uses: espressif/esp-idf-ci-action@v1
-        with:
-          esp_idf_version: latest
-          path: firmware
-          command: idf.py test

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -19,4 +19,5 @@ message-parsing behaviour without requiring an ESP32.
 ESP-IDF's built-in test runner executes tests on the target or in the ESP-IDF
 emulation environment. Running `idf.py test` within the `firmware` directory
 builds and runs these tests to assert correct integration with the ESP-IDF
-framework.
+framework. These tests are not executed in continuous integration and should
+be run locally when developing firmware changes.


### PR DESCRIPTION
## Summary
- drop ESP-IDF firmware test step from CI
- document that firmware unit tests must be run locally

## Testing
- `pytest`
- `cmake -S firmware/test -B firmware/test/build`
- `cmake --build firmware/test/build`
- `./firmware/test/build/test_rx_task`
- `idf.py test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b101781fc88322922bfa76d9c03fb5