### PR TITLE
docs: clarify ESP-IDF build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,12 @@ For ESP-IDF unit tests and more details on the testing strategy, see
 
 Build firmware (requires ESP-IDF):
 
+Ensure the [ESP-IDF](https://docs.espressif.com/projects/esp-idf/) environment is installed
+and exported so that the `idf.py` helper is on your `PATH` (e.g. `. $IDF_PATH/export.sh`).
+Then run:
+
 ```
 cd firmware
+idf.py set-target esp32
 idf.py build
 ```

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -13,9 +13,11 @@ This directory contains the ESP-IDF based firmware for the Barn Lights system.
 
 ## Building
 
-Ensure ESP-IDF is installed and in your PATH. Then run:
+Ensure the ESP-IDF environment is installed and exported so that `idf.py`
+is available (e.g. `. $IDF_PATH/export.sh`). Then run:
 
 ```
+idf.py set-target esp32
 idf.py build
 ```
 


### PR DESCRIPTION
## Summary
- explain that `idf.py` is available only after activating the ESP-IDF environment
- update build instructions to run `idf.py set-target esp32` before `idf.py build`

## Testing
- `pytest`
- `cmake -S firmware/test -B firmware/test/build`
- `cmake --build firmware/test/build`
- `./firmware/test/build/test_rx_task`
- `./firmware/test/build/test_status_task`


------
https://chatgpt.com/codex/tasks/task_e_68b10f89f7448322b40e5d7adf8465da