### PR TITLE
Use PRIu32 for 32-bit status counters

### DIFF
--- a/firmware/main/status_task.c
+++ b/firmware/main/status_task.c
@@ -1,6 +1,7 @@
 #include "status_task.h"
 #include "config_autogen.h"
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -42,7 +43,7 @@ size_t status_task_format_json(char *buffer, size_t buffer_len, uint32_t uptime_
     snprintf(ip_str, sizeof(ip_str), "%u.%u.%u.%u", STATIC_IP_ADDR0, STATIC_IP_ADDR1, STATIC_IP_ADDR2, STATIC_IP_ADDR3);
     size_t offset = 0;
     offset += snprintf(buffer + offset, buffer_len - offset,
-                       "{\"id\":\"%s\",\"ip\":\"%s\",\"uptime_ms\":%u,\"link\":%s,\"runs\":%u,\"leds\":[",
+                       "{\"id\":\"%s\",\"ip\":\"%s\",\"uptime_ms\":%" PRIu32 ",\"link\":%s,\"runs\":%u,\"leds\":[",
                        SIDE_ID_STR, ip_str, uptime_ms, link ? "true" : "false", RUN_COUNT);
     for (unsigned int i = 0; i < RUN_COUNT; ++i) {
         offset += snprintf(buffer + offset, buffer_len - offset, "%u", LED_COUNT[i]);
@@ -51,7 +52,7 @@ size_t status_task_format_json(char *buffer, size_t buffer_len, uint32_t uptime_
         }
     }
     offset += snprintf(buffer + offset, buffer_len - offset,
-                       "],\"rx_frames\":%u,\"complete\":%u,\"applied\":%u,\"dropped_frames\":%u,\"errors\":[]}",
+                       "],\"rx_frames\":%" PRIu32 ",\"complete\":%" PRIu32 ",\"applied\":%" PRIu32 ",\"dropped_frames\":%" PRIu32 ",\"errors\":[]}",
                        rx_frames_count, complete_count, applied_count, dropped_count);
     return offset;
 }


### PR DESCRIPTION
## Summary
- include `<inttypes.h>` in `status_task.c`
- print uptime and counter fields with `PRIu32`

## Testing
- `pytest`
- `cmake -S firmware/test -B firmware/test/build -DCMAKE_C_FLAGS='-DSTATIC_IP_ADDR0=192 -DSTATIC_IP_ADDR1=168 -DSTATIC_IP_ADDR2=0 -DSTATIC_IP_ADDR3=50'`
- `cmake --build firmware/test/build`
- `./firmware/test/build/test_rx_task`
- `./firmware/test/build/test_status_task`


------
https://chatgpt.com/codex/tasks/task_e_68b129c5a8448322b33d6e5fffe9abbc