### PR TITLE
Refactor Ethernet init for ESP-IDF updates

### DIFF
--- a/firmware/main/net_task.c
+++ b/firmware/main/net_task.c
@@ -5,6 +5,7 @@
 #include "esp_eth.h"
 #include "esp_netif.h"
 #include "esp_log.h"
+#include "lwip/ip4_addr.h"
 #include "config_autogen.h"
 
 // Compile-time checks for static IP configuration
@@ -81,13 +82,13 @@ static void network_task(void *param)
     phy_config.reset_gpio_num = -1;
 
     eth_esp32_emac_config_t emac_config = ETH_ESP32_EMAC_DEFAULT_CONFIG();
-    emac_config.smi_mdc_gpio_num = RMII_MDC_GPIO;
-    emac_config.smi_mdio_gpio_num = RMII_MDIO_GPIO;
+    emac_config.smi_gpio.mdc = RMII_MDC_GPIO;
+    emac_config.smi_gpio.mdio = RMII_MDIO_GPIO;
     emac_config.clock_config.rmii.clock_mode = EMAC_CLK_OUT;
     emac_config.clock_config.rmii.clock_gpio = RMII_REF_CLK_GPIO;
 
-    esp_eth_mac_t *mac = esp_eth_mac_new_esp32(&mac_config, &emac_config);
-    esp_eth_phy_t *phy = esp_eth_phy_new_lan8720(&phy_config);
+    esp_eth_mac_t *mac = esp_eth_mac_new_esp32(&emac_config, &mac_config);
+    esp_eth_phy_t *phy = esp_eth_phy_new_lan87xx(&phy_config);
 
     esp_eth_config_t eth_config = ETH_DEFAULT_CONFIG(mac, phy);
     esp_eth_handle_t eth_handle = NULL;

--- a/firmware/main/net_task.md
+++ b/firmware/main/net_task.md
@@ -1,6 +1,6 @@
 # Network Task
 
-Initialises the ESP32 Ethernet interface using the LAN8720 PHY. The task configures the RMII pins, installs the EMAC driver and assigns a static IP address using values generated in `config_autogen.h`.
+Initialises the ESP32 Ethernet interface using a LAN87xx series PHY. The task configures the RMII pins, installs the EMAC driver and assigns a static IP address using values generated in `config_autogen.h`.
 
 Once the interface is started, the task sets `NETWORK_READY_BIT` on its event group to signal that the network stack is ready for use.
 

--- a/firmware/main/test/test_net_task.c
+++ b/firmware/main/test/test_net_task.c
@@ -7,14 +7,12 @@
 
 #define ESP_LOGI(tag, fmt, ...)
 #define vTaskDelay(...) return
-#define IP4_ADDR(addr, a,b,c,d)
 
 #define static
 #include "net_task.c"
 #undef static
 #undef vTaskDelay
 #undef ESP_LOGI
-#undef IP4_ADDR
 
 void setUp(void)
 {
@@ -32,7 +30,7 @@ void test_network_task_sets_ready_bit(void)
     esp_event_loop_create_default_ExpectAndReturn(ESP_OK);
     esp_netif_new_ExpectAnyArgsAndReturn((esp_netif_t *)1);
     esp_eth_mac_new_esp32_ExpectAnyArgsAndReturn((esp_eth_mac_t *)1);
-    esp_eth_phy_new_lan8720_ExpectAnyArgsAndReturn((esp_eth_phy_t *)1);
+    esp_eth_phy_new_lan87xx_ExpectAnyArgsAndReturn((esp_eth_phy_t *)1);
     esp_eth_driver_install_ExpectAnyArgsAndReturn(ESP_OK);
     esp_netif_attach_ExpectAnyArgsAndReturn(ESP_OK);
     esp_eth_new_netif_glue_ExpectAnyArgsAndReturn((void *)1);


### PR DESCRIPTION
## Summary
- use generic LAN87xx PHY factory and new SMI GPIO fields
- swap esp_eth_mac_new_esp32 argument order
- include lwIP IP4_ADDR header and update docs

## Testing
- `idf.py test -T main/test` *(fails: command not found: idf.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b12a3108ec8322a08572ef0fdaba2d