### PR TITLE
fix: update EMAC config for IDF 5

### DIFF
--- a/firmware/main/net_task.c
+++ b/firmware/main/net_task.c
@@ -82,8 +82,8 @@ static void network_task(void *param)
     phy_config.reset_gpio_num = -1;
 
     eth_esp32_emac_config_t emac_config = ETH_ESP32_EMAC_DEFAULT_CONFIG();
-    emac_config.smi_gpio.mdc = RMII_MDC_GPIO;
-    emac_config.smi_gpio.mdio = RMII_MDIO_GPIO;
+    emac_config.smi_mdc_gpio_num = RMII_MDC_GPIO;
+    emac_config.smi_mdio_gpio_num = RMII_MDIO_GPIO;
     emac_config.clock_config.rmii.clock_mode = EMAC_CLK_OUT;
     emac_config.clock_config.rmii.clock_gpio = RMII_REF_CLK_GPIO;
 


### PR DESCRIPTION
## Summary
- update EMAC config field names for new ESP-IDF

## Testing
- `cmake -S firmware/test -B firmware/test/build`
- `cmake --build firmware/test/build`
- `./firmware/test/build/test_rx_task`
- `./firmware/test/build/test_status_task`
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b12f064f748322a0dc7fa843365ea9