### PR TITLE
Copy RGB packets verbatim in rx_task

### DIFF
--- a/firmware/main/rx_task.c
+++ b/firmware/main/rx_task.c
@@ -80,16 +80,11 @@ void rx_task_process_packet(unsigned int run_index, const uint8_t *data, size_t 
         return;
     }
 
-    const uint8_t *src = data + 4;
-    uint8_t *dest = frame_buffers[target_slot == current_slot ? current_slot_index : 1 - current_slot_index][run_index];
-    for (unsigned int i = 0; i < LED_COUNT[run_index]; ++i) {
-        uint8_t red = src[i * 3];
-        uint8_t green = src[i * 3 + 1];
-        uint8_t blue = src[i * 3 + 2];
-        dest[i * 3] = green;
-        dest[i * 3 + 1] = red;
-        dest[i * 3 + 2] = blue;
-    }
+    size_t payload_length = LED_COUNT[run_index] * 3;
+    uint8_t *destination_buffer =
+        frame_buffers[target_slot == current_slot ? current_slot_index : 1 - current_slot_index][run_index];
+    // Copy payload as-is; driver_task handles any RGB to GRB reordering.
+    memcpy(destination_buffer, data + 4, payload_length);
     target_slot->run_received[run_index] = true;
 
     bool complete = true;

--- a/firmware/test/test_rx_task.c
+++ b/firmware/test/test_rx_task.c
@@ -21,19 +21,19 @@ void test_invalid_length_ignored(void) {
     free(packet);
 }
 
-void test_rgb_to_grb(void) {
-    size_t len = 4 + LED_COUNT[0] * 3;
-    uint8_t *packet = (uint8_t *)malloc(len);
-    memset(packet, 0, len);
+void test_copy_payload_without_reordering(void) {
+    size_t length = 4 + LED_COUNT[0] * 3;
+    uint8_t *packet = (uint8_t *)malloc(length);
+    memset(packet, 0, length);
     packet[3] = 1;
     packet[4] = 1; // R
     packet[5] = 2; // G
     packet[6] = 3; // B
-    rx_task_process_packet(0, packet, len);
-    const uint8_t *out = rx_task_get_run_buffer(0, 0);
-    TEST_ASSERT_EQUAL_UINT8(2, out[0]);
-    TEST_ASSERT_EQUAL_UINT8(1, out[1]);
-    TEST_ASSERT_EQUAL_UINT8(3, out[2]);
+    rx_task_process_packet(0, packet, length);
+    const uint8_t *buffer = rx_task_get_run_buffer(0, 0);
+    TEST_ASSERT_EQUAL_UINT8(1, buffer[0]);
+    TEST_ASSERT_EQUAL_UINT8(2, buffer[1]);
+    TEST_ASSERT_EQUAL_UINT8(3, buffer[2]);
     free(packet);
 }
 
@@ -63,7 +63,7 @@ void test_frame_slots_only_keep_current_and_next(void) {
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_invalid_length_ignored);
-    RUN_TEST(test_rgb_to_grb);
+    RUN_TEST(test_copy_payload_without_reordering);
     RUN_TEST(test_frame_slots_only_keep_current_and_next);
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary
- Remove RGB to GRB reordering loop in `rx_task` so incoming packet payloads are stored as-is
- Update unit tests to expect direct RGB copying rather than color reordering

## Testing
- `cmake -S firmware/test -B firmware/test/build`
- `cmake --build firmware/test/build`
- `./firmware/test/build/test_rx_task`
- `./firmware/test/build/test_status_task`


------
https://chatgpt.com/codex/tasks/task_e_68b131faff348322ae50148cf4e3ac0f