### PR TITLE
Add build and test automation scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,17 @@ cd firmware
 idf.py set-target esp32
 idf.py build
 ```
+
+### Convenience scripts
+
+To build the application and generate configuration, run:
+
+```
+./build_app.sh
+```
+
+To execute all test suites sequentially, run:
+
+```
+./run_all_tests.sh
+```

--- a/build_app.sh
+++ b/build_app.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Generate configuration
+python tools/gen_config.py --layout left.json
+
+# Build firmware
+pushd firmware >/dev/null
+idf.py fullclean
+idf.py build
+popd >/dev/null

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run Python tests
+pytest
+
+# Build and run host tests
+cmake -S firmware/test -B firmware/test/build
+cmake --build firmware/test/build
+./firmware/test/build/test_rx_task
+
+# Execute firmware unit tests
+pushd firmware >/dev/null
+idf.py test
+popd >/dev/null


### PR DESCRIPTION
## Summary
- add script to generate configuration and build firmware
- add script to run Python, host, and firmware tests in sequence
- document new helper scripts in README

## Testing
- `pytest`
- `cmake -S firmware/test -B firmware/test/build && cmake --build firmware/test/build && ./firmware/test/build/test_rx_task`
- `./run_all_tests.sh` *(fails: idf.py: command not found)*
- `./build_app.sh` *(fails: idf.py: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1aa8ef37083228c05e766a5c7f590