### PR TITLE
Track frame counters in rx and driver tasks

### DIFF
--- a/firmware/main/driver_task.c
+++ b/firmware/main/driver_task.c
@@ -2,6 +2,7 @@
 
 #include "config_autogen.h"
 #include "rx_task.h"
+#include "status_task.h"
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -139,6 +140,7 @@ static void driver_task(void *arg)
         bool blackout_elapsed = (now - start_tick) >= pdMS_TO_TICKS(1000);
         if (selected_slot >= 0 && blackout_elapsed) {
             send_frame(selected_slot);
+            status_task_increment_applied();
             last_frame_id = selected_id;
             first_frame_sent = true;
         }

--- a/firmware/main/rx_task.c
+++ b/firmware/main/rx_task.c
@@ -1,6 +1,7 @@
 #include "rx_task.h"
 
 #include "config_autogen.h"
+#include "status_task.h"
 
 #include <stdbool.h>
 #include <stdlib.h>
@@ -48,10 +49,12 @@ static void clear_slot(FrameSlot *slot) {
 
 void rx_task_process_packet(unsigned int run_index, const uint8_t *data, size_t length) {
     if (run_index >= RUN_COUNT) {
+        status_task_increment_drops();
         return;
     }
     size_t expected_length = LED_COUNT[run_index] * 3 + 4;
     if (length != expected_length) {
+        status_task_increment_drops();
         return;
     }
     uint32_t frame_id = ((uint32_t)data[0] << 24) |
@@ -74,11 +77,15 @@ void rx_task_process_packet(unsigned int run_index, const uint8_t *data, size_t 
             next_slot->frame_id = frame_id;
             target_slot = next_slot;
         } else {
+            status_task_increment_drops();
             return;
         }
     } else {
+        status_task_increment_drops();
         return;
     }
+
+    status_task_increment_rx_frames();
 
     const uint8_t *src = data + 4;
     uint8_t *dest = frame_buffers[target_slot == current_slot ? current_slot_index : 1 - current_slot_index][run_index];
@@ -98,6 +105,9 @@ void rx_task_process_packet(unsigned int run_index, const uint8_t *data, size_t 
             complete = false;
             break;
         }
+    }
+    if (complete) {
+        status_task_increment_complete();
     }
     if (target_slot == next_slot && complete) {
         current_slot_index = 1 - current_slot_index;

--- a/firmware/test/CMakeLists.txt
+++ b/firmware/test/CMakeLists.txt
@@ -18,6 +18,7 @@ endif()
 add_executable(test_rx_task
     test_rx_task.c
     ../main/rx_task.c
+    ../main/status_task.c
 )
 
 target_include_directories(test_rx_task PRIVATE ../include ../main)


### PR DESCRIPTION
## Summary
- Count dropped, received, and completed frames in `rx_task` via `status_task`
- Bump applied frame counter after `driver_task` sends a frame
- Link `status_task` into rx unit tests

## Testing
- `pytest -q tools/tests`
- `cmake -S firmware/test -B firmware/test/build`
- `cmake --build firmware/test/build`
- `./firmware/test/build/test_rx_task`
- `./firmware/test/build/test_status_task`


------
https://chatgpt.com/codex/tasks/task_e_68b131fcc8a08322acae73b75cd0e757