### PR TITLE
Flash runs sequentially on startup

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -7,7 +7,7 @@ This directory contains the ESP-IDF based firmware for the Barn Lights system.
 - **main/**: entry point containing `app_main.c`. It creates FreeRTOS tasks:
   - `network_task` handles networking.
   - `rx_task` processes inbound messages.
-  - `driver_task` drives the light output with one RMT channel per run, triggering channels simultaneously and, on startup, flashing each run for one second with RGB 218,170,52 after an initial one second delay.
+  - `driver_task` drives the light output with one RMT channel per run, triggering channels simultaneously and, on startup, using `startup_sequence.c` to flash each run for one second with RGB 218,170,52 after an initial one second delay.
   - `status_task` emits a heartbeat JSON every second to `SENDER_IP:STATUS_PORT` containing runtime counters.
 - **components/**: custom components for the firmware (currently empty).
 

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -7,7 +7,7 @@ This directory contains the ESP-IDF based firmware for the Barn Lights system.
 - **main/**: entry point containing `app_main.c`. It creates FreeRTOS tasks:
   - `network_task` handles networking.
   - `rx_task` processes inbound messages.
-  - `driver_task` drives the light output with one RMT channel per run, triggering channels simultaneously and enforcing a one second blackout at boot.
+  - `driver_task` drives the light output with one RMT channel per run, triggering channels simultaneously and, on startup, flashing each run for one second with RGB 218,170,52 after an initial one second delay.
   - `status_task` emits a heartbeat JSON every second to `SENDER_IP:STATUS_PORT` containing runtime counters.
 - **components/**: custom components for the firmware (currently empty).
 

--- a/firmware/main/CMakeLists.txt
+++ b/firmware/main/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(
-    SRCS "app_main.c" "net_task.c" "rx_task.c" "driver_task.c" "status_task.c"
+    SRCS "app_main.c" "net_task.c" "rx_task.c" "driver_task.c" "status_task.c" "startup_sequence.c"
     INCLUDE_DIRS "." "../include"
 )

--- a/firmware/main/README.md
+++ b/firmware/main/README.md
@@ -4,7 +4,7 @@ Application entry point and task startup. `app_main.c` creates FreeRTOS tasks fo
 
 - `net_task.c` initialises Ethernet and raises `NETWORK_READY_BIT` once the interface is ready.
 - `rx_task.c` opens UDP sockets on `PORT_BASE + run_index`, validates packet length, and assembles frame buffers keyed by `frame_id`, keeping only the current and next frames.
-- `driver_task.c` configures one RMT channel per run using the modern `rmt_tx` API and triggers them simultaneously. On boot it enforces a one second blackout before displaying the first complete frame, swapping buffers when a new frame arrives and converting RGB bytes to GRB during encoding. Compile-time checks verify RMT timing.
+- `driver_task.c` configures one RMT channel per run using the modern `rmt_tx` API and triggers them simultaneously. On boot it waits one second, flashes each run for one second with RGB 218,170,52 in sequence, then begins displaying frames, swapping buffers when a new frame arrives and converting RGB bytes to GRB during encoding. Compile-time checks verify RMT timing.
 - `status_task.c` sends a heartbeat JSON every second to `SENDER_IP:STATUS_PORT`, reporting counters since the previous heartbeat.
 
 Unit tests reside in `test/test_net_task.c` with `test/CMakeLists.txt` wiring them into the ESP-IDF `idf.py test` workflow.

--- a/firmware/main/README.md
+++ b/firmware/main/README.md
@@ -4,7 +4,7 @@ Application entry point and task startup. `app_main.c` creates FreeRTOS tasks fo
 
 - `net_task.c` initialises Ethernet and raises `NETWORK_READY_BIT` once the interface is ready.
 - `rx_task.c` opens UDP sockets on `PORT_BASE + run_index`, validates packet length, and assembles frame buffers keyed by `frame_id`, keeping only the current and next frames.
-- `driver_task.c` configures one RMT channel per run using the modern `rmt_tx` API and triggers them simultaneously. On boot it waits one second, flashes each run for one second with RGB 218,170,52 in sequence, then begins displaying frames, swapping buffers when a new frame arrives and converting RGB bytes to GRB during encoding. Compile-time checks verify RMT timing.
+- `driver_task.c` configures one RMT channel per run using the modern `rmt_tx` API and triggers them simultaneously. On boot it waits one second, then `startup_sequence.c` flashes each run for one second with RGB 218,170,52 in sequence before frame display begins, swapping buffers when a new frame arrives and converting RGB bytes to GRB during encoding. Compile-time checks verify RMT timing.
 - `status_task.c` sends a heartbeat JSON every second to `SENDER_IP:STATUS_PORT`, reporting counters since the previous heartbeat.
 
 Unit tests reside in `test/test_net_task.c` with `test/CMakeLists.txt` wiring them into the ESP-IDF `idf.py test` workflow.

--- a/firmware/main/startup_sequence.c
+++ b/firmware/main/startup_sequence.c
@@ -1,0 +1,15 @@
+#include "startup_sequence.h"
+
+void startup_sequence(unsigned int run_count,
+                      flash_run_fn flash_run,
+                      send_black_fn send_black,
+                      delay_ms_fn delay_ms)
+{
+    delay_ms(1000);
+    for (unsigned int run = 0; run < run_count; ++run) {
+        flash_run(run, STARTUP_RED, STARTUP_GREEN, STARTUP_BLUE);
+        delay_ms(1000);
+        send_black();
+    }
+}
+

--- a/firmware/main/startup_sequence.h
+++ b/firmware/main/startup_sequence.h
@@ -1,0 +1,20 @@
+#ifndef STARTUP_SEQUENCE_H
+#define STARTUP_SEQUENCE_H
+
+#include <stdint.h>
+
+#define STARTUP_RED 218
+#define STARTUP_GREEN 170
+#define STARTUP_BLUE 52
+
+typedef void (*flash_run_fn)(unsigned int run_index,
+                             uint8_t red, uint8_t green, uint8_t blue);
+typedef void (*send_black_fn)(void);
+typedef void (*delay_ms_fn)(uint32_t ms);
+
+void startup_sequence(unsigned int run_count,
+                      flash_run_fn flash_run,
+                      send_black_fn send_black,
+                      delay_ms_fn delay_ms);
+
+#endif // STARTUP_SEQUENCE_H

--- a/firmware/test/CMakeLists.txt
+++ b/firmware/test/CMakeLists.txt
@@ -34,3 +34,12 @@ target_include_directories(test_status_task PRIVATE ../include ../main)
 target_compile_definitions(test_status_task PRIVATE UNIT_TEST)
 target_link_libraries(test_status_task unity)
 
+add_executable(test_startup_sequence
+    test_startup_sequence.c
+    ../main/startup_sequence.c
+)
+
+target_include_directories(test_startup_sequence PRIVATE ../include ../main)
+target_compile_definitions(test_startup_sequence PRIVATE UNIT_TEST)
+target_link_libraries(test_startup_sequence unity)
+

--- a/firmware/test/test_startup_sequence.c
+++ b/firmware/test/test_startup_sequence.c
@@ -1,0 +1,54 @@
+#include "unity.h"
+#include "startup_sequence.h"
+
+static unsigned int flashed_runs[8];
+static unsigned int flash_count;
+static void flash_stub(unsigned int run_index,
+                       uint8_t red, uint8_t green, uint8_t blue)
+{
+    flashed_runs[flash_count++] = run_index;
+    TEST_ASSERT_EQUAL_UINT8(STARTUP_RED, red);
+    TEST_ASSERT_EQUAL_UINT8(STARTUP_GREEN, green);
+    TEST_ASSERT_EQUAL_UINT8(STARTUP_BLUE, blue);
+}
+
+static unsigned int black_count;
+static void black_stub(void)
+{
+    ++black_count;
+}
+
+static unsigned int delay_count;
+static uint32_t delays[8];
+static void delay_stub(uint32_t ms)
+{
+    delays[delay_count++] = ms;
+}
+
+void test_startup_sequence_flashes_runs_sequentially(void)
+{
+    flash_count = 0;
+    black_count = 0;
+    delay_count = 0;
+    startup_sequence(3, flash_stub, black_stub, delay_stub);
+    TEST_ASSERT_EQUAL_UINT(3, flash_count);
+    TEST_ASSERT_EQUAL_UINT(3, black_count);
+    TEST_ASSERT_EQUAL_UINT32(4, delay_count);
+    for (unsigned int i = 0; i < delay_count; ++i) {
+        TEST_ASSERT_EQUAL_UINT32(1000, delays[i]);
+    }
+    TEST_ASSERT_EQUAL_UINT(0, flashed_runs[0]);
+    TEST_ASSERT_EQUAL_UINT(1, flashed_runs[1]);
+    TEST_ASSERT_EQUAL_UINT(2, flashed_runs[2]);
+}
+
+void setUp(void) {}
+void tearDown(void) {}
+
+int main(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_startup_sequence_flashes_runs_sequentially);
+    return UNITY_END();
+}
+


### PR DESCRIPTION
## Summary
- flash each run for one second with RGB 218,170,52 after a one second wait at startup
- document the new startup sequence

## Testing
- `./run_all_tests.sh` *(fails: idf.py: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3d62388148322b3baa205782b3f5d