### PR TITLE
Make config generation tests handle variable run counts

### DIFF
--- a/firmware/test/README.md
+++ b/firmware/test/README.md
@@ -1,6 +1,6 @@
 # Tests
 
-Host-side unit tests for firmware modules. Unity is fetched during the CMake configure step using `FetchContent` from the official repository (tag `v2.5.2`).
+Host-side unit tests for firmware modules. Unity is fetched during the CMake configure step using `FetchContent` from the official repository (tag `v2.5.2`). Tests read run counts and LED lengths from `config_autogen.h` so layouts with any number of runs can be exercised.
 
 ## Building and Running
 

--- a/firmware/test/test_status_task.c
+++ b/firmware/test/test_status_task.c
@@ -12,13 +12,26 @@ void test_format_json(void) {
     status_task_increment_complete();
     status_task_increment_applied();
     status_task_increment_drops();
+
     char json_buffer[256];
     size_t json_length = status_task_format_json(json_buffer, sizeof(json_buffer), 123, true);
+
+    const char *side_str = SIDE_ID == 0 ? "LEFT" : "RIGHT";
     char expected[256];
-    snprintf(expected, sizeof(expected),
-             "{\"id\":\"LEFT\",\"ip\":\"%u.%u.%u.%u\",\"uptime_ms\":123,\"link\":true,\"runs\":3,\"leds\":[400,400,400],\"rx_frames\":1,\"complete\":1,\"applied\":1,\"dropped_frames\":1,\"errors\":[]}",
-             STATIC_IP_ADDR0, STATIC_IP_ADDR1, STATIC_IP_ADDR2, STATIC_IP_ADDR3);
-    TEST_ASSERT_EQUAL(strlen(expected), json_length);
+    size_t offset = 0;
+    offset += snprintf(expected + offset, sizeof(expected) - offset,
+                       "{\"id\":\"%s\",\"ip\":\"%u.%u.%u.%u\",\"uptime_ms\":123,\"link\":true,\"runs\":%u,\"leds\":[",
+                       side_str, STATIC_IP_ADDR0, STATIC_IP_ADDR1, STATIC_IP_ADDR2, STATIC_IP_ADDR3, RUN_COUNT);
+    for (unsigned int i = 0; i < RUN_COUNT; ++i) {
+        offset += snprintf(expected + offset, sizeof(expected) - offset, "%u", LED_COUNT[i]);
+        if (i + 1 < RUN_COUNT) {
+            offset += snprintf(expected + offset, sizeof(expected) - offset, ",");
+        }
+    }
+    offset += snprintf(expected + offset, sizeof(expected) - offset,
+                       "],\"rx_frames\":1,\"complete\":1,\"applied\":1,\"dropped_frames\":1,\"errors\":[]}");
+
+    TEST_ASSERT_EQUAL(offset, json_length);
     TEST_ASSERT_EQUAL_STRING(expected, json_buffer);
 }
 

--- a/tools/readme.md
+++ b/tools/readme.md
@@ -1,6 +1,6 @@
 # Tools
 
-The `gen_config.py` script reads a layout JSON file and writes `firmware/include/config_autogen.h` with constants used by the firmware. Layout files must include `static_ip`, `static_netmask`, and `static_gateway` fields, each listing four integer octets. These values become the `STATIC_IP_ADDR*`, `STATIC_NETMASK_ADDR*`, and `STATIC_GW_ADDR*` macros in the generated header.
+The `gen_config.py` script reads a layout JSON file and writes `firmware/include/config_autogen.h` with constants used by the firmware. Layout files must include `static_ip`, `static_netmask`, and `static_gateway` fields, each listing four integer octets. These values become the `STATIC_IP_ADDR*`, `STATIC_NETMASK_ADDR*`, and `STATIC_GW_ADDR*` macros in the generated header. The number of LED runs in the layout is unrestricted; `RUN_COUNT` and the `LED_COUNT` array are derived from the provided runs.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- test tools for generated config adapt to any number of LED runs
- document that gen_config derives RUN_COUNT and LED_COUNT from the runs list

## Testing
- `pytest tools/tests/test_gen_config.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b48dd1a7948322a4df22bc83da64e0