### PR TITLE
Remove sync manager; send runs sequentially

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -7,7 +7,7 @@ This directory contains the ESP-IDF based firmware for the Barn Lights system.
 - **main/**: entry point containing `app_main.c`. It creates FreeRTOS tasks:
   - `network_task` handles networking.
   - `rx_task` processes inbound messages.
-  - `driver_task` drives the light output with one RMT channel per run, triggering channels simultaneously and, on startup, using `startup_sequence.c` to flash each run for one second with RGB 218,170,52 after an initial one second delay.
+  - `driver_task` drives the light output with one RMT channel per run and, in the absence of a sync manager, sends each run sequentially. On startup it uses `startup_sequence.c` to flash each run for one second with RGB 218,170,52 after an initial one second delay.
   - `status_task` emits a heartbeat JSON every second to `SENDER_IP:STATUS_PORT` containing runtime counters.
 - **components/**: custom components for the firmware (currently empty).
 

--- a/firmware/main/README.md
+++ b/firmware/main/README.md
@@ -4,7 +4,7 @@ Application entry point and task startup. `app_main.c` creates FreeRTOS tasks fo
 
 - `net_task.c` initialises Ethernet and raises `NETWORK_READY_BIT` once the interface is ready.
 - `rx_task.c` opens UDP sockets on `PORT_BASE + run_index`, validates packet length, and assembles frame buffers keyed by `frame_id`, keeping only the current and next frames.
-- `driver_task.c` configures one RMT channel per run using the modern `rmt_tx` API and triggers them simultaneously. On boot it waits one second, then `startup_sequence.c` flashes each run for one second with RGB 218,170,52 in sequence before frame display begins, swapping buffers when a new frame arrives and converting RGB bytes to GRB during encoding. Compile-time checks verify RMT timing.
+- `driver_task.c` configures one RMT channel per run using the modern `rmt_tx` API and transmits each run sequentially, waiting for one run to finish before starting the next. On boot it waits one second, then `startup_sequence.c` flashes each run for one second with RGB 218,170,52 in sequence before frame display begins, swapping buffers when a new frame arrives and converting RGB bytes to GRB during encoding. Compile-time checks verify RMT timing.
 - `status_task.c` sends a heartbeat JSON every second to `SENDER_IP:STATUS_PORT`, reporting counters since the previous heartbeat.
 
 Unit tests reside in `test/test_net_task.c` with `test/CMakeLists.txt` wiring them into the ESP-IDF `idf.py test` workflow.


### PR DESCRIPTION
## Summary
- remove sync manager usage from driver task
- transmit LED runs sequentially with rmt_transmit and rmt_tx_wait_all_done
- document sequential driver behaviour in main firmware readmes

## Testing
- `./run_all_tests.sh` (fails: idf.py: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68b4a416f1788322917afaaac99d7c0f