### PR TITLE
Fix Ethernet resource cleanup build error

### DIFF
--- a/firmware/main/net_task.c
+++ b/firmware/main/net_task.c
@@ -3,6 +3,8 @@
 #include "freertos/task.h"
 #include "esp_event.h"
 #include "esp_eth.h"
+#include "esp_eth_mac.h"
+#include "esp_eth_phy.h"
 #include "esp_netif.h"
 #include "esp_log.h"
 #include "lwip/ip4_addr.h"
@@ -98,8 +100,8 @@ static void network_task(void *param)
     if (driver_install_status != ESP_OK) {
         ESP_LOGE(LOG_TAG, "esp_eth_driver_install failed: %s", esp_err_to_name(driver_install_status));
         esp_netif_destroy(netif);
-        esp_eth_mac_free(mac);
-        esp_eth_phy_free(phy);
+        esp_eth_mac_del(mac);
+        esp_eth_phy_del(phy);
         vTaskDelete(NULL);
         return;
     }


### PR DESCRIPTION
## Summary
- include missing Ethernet MAC/PHY headers
- replace obsolete esp_eth_mac_free/esp_eth_phy_free with esp_eth_mac_del/esp_eth_phy_del

## Testing
- `./run_all_tests.sh` *(fails: idf.py: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c31d8f408322b485f662625d3b07