### PR TITLE
Fix Ethernet resource cleanup build error

### DIFF
--- a/firmware/main/net_task.c
+++ b/firmware/main/net_task.c
@@ -3,6 +3,8 @@
 #include "freertos/task.h"
 #include "esp_event.h"
 #include "esp_eth.h"
+#include "esp_eth_mac.h"
+#include "esp_eth_phy.h"
 #include "esp_netif.h"
 #include "esp_log.h"
 #include "lwip/ip4_addr.h"


### PR DESCRIPTION
## Summary
- include missing Ethernet MAC/PHY headers
- use esp_eth_mac_free/esp_eth_phy_free for cleanup to match ESP-IDF API

## Testing
- `./run_all_tests.sh` *(fails: idf.py: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c31d8f408322b485f662625d3b07