### PR TITLE
Fix Ethernet resource cleanup build error

### DIFF
--- a/firmware/main/net_task.c
+++ b/firmware/main/net_task.c
@@ -3,6 +3,9 @@
 #include "freertos/task.h"
 #include "esp_event.h"
 #include "esp_eth.h"
+#include "esp_eth_mac.h"
+#include "esp_eth_phy.h"
+#include "esp_idf_version.h"
 #include "esp_netif.h"
 #include "esp_log.h"
 #include "lwip/ip4_addr.h"
@@ -98,8 +101,13 @@ static void network_task(void *param)
     if (driver_install_status != ESP_OK) {
         ESP_LOGE(LOG_TAG, "esp_eth_driver_install failed: %s", esp_err_to_name(driver_install_status));
         esp_netif_destroy(netif);
+#if ESP_IDF_VERSION_MAJOR >= 5
+        esp_eth_mac_del(mac);
+        esp_eth_phy_del(phy);
+#else
         esp_eth_mac_free(mac);
         esp_eth_phy_free(phy);
+#endif
         vTaskDelete(NULL);
         return;
     }


### PR DESCRIPTION
## Summary
- include esp_idf_version.h for ESP-IDF version detection
- conditionally call esp_eth_mac_del/esp_eth_phy_del or legacy free functions based on ESP-IDF version

## Testing
- `./run_all_tests.sh` *(fails: idf.py: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c31d8f408322b485f662625d3b07