### PR TITLE
Use internal Ethernet clock output

### DIFF
--- a/firmware/main/net_task.c
+++ b/firmware/main/net_task.c
@@ -88,7 +88,7 @@ static void network_task(void *param)
     eth_esp32_emac_config_t emac_config = ETH_ESP32_EMAC_DEFAULT_CONFIG();
     emac_config.smi_gpio.mdc_num = RMII_MDC_GPIO;
     emac_config.smi_gpio.mdio_num = RMII_MDIO_GPIO;
-    emac_config.clock_config.rmii.clock_mode = EMAC_CLK_EXT_IN;
+    emac_config.clock_config.rmii.clock_mode = EMAC_CLK_OUT;
     emac_config.clock_config.rmii.clock_gpio = RMII_REF_CLK_GPIO;
 
     esp_eth_mac_t *mac = esp_eth_mac_new_esp32(&emac_config, &mac_config);


### PR DESCRIPTION
## Summary
- drive RMII reference clock from the ESP32 using `EMAC_CLK_OUT`

## Testing
- `./run_all_tests.sh` *(fails: idf.py: command not found)*
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d69c8ad48322979d1288b694cf58