### PR TITLE
Skip PHY reset

### DIFF
--- a/firmware/main/net_task.c
+++ b/firmware/main/net_task.c
@@ -58,16 +58,14 @@ _Static_assert(STATIC_GW_ADDR0 <= 255 && STATIC_GW_ADDR1 <= 255 &&
                STATIC_GW_ADDR2 <= 255 && STATIC_GW_ADDR3 <= 255,
                "Gateway octets must be in range 0-255");
 
-// RMII pin configuration
+// RMII pin configuration (PHY reset skipped)
 #define RMII_MDC_GPIO 23
 #define RMII_MDIO_GPIO 18
 #define RMII_REF_CLK_GPIO 0
-#define RMII_RESET_GPIO 5
 
 _Static_assert(RMII_MDC_GPIO >= 0 && RMII_MDC_GPIO <= 39, "RMII_MDC_GPIO out of range");
 _Static_assert(RMII_MDIO_GPIO >= 0 && RMII_MDIO_GPIO <= 39, "RMII_MDIO_GPIO out of range");
 _Static_assert(RMII_REF_CLK_GPIO >= 0 && RMII_REF_CLK_GPIO <= 39, "RMII_REF_CLK_GPIO out of range");
-_Static_assert(RMII_RESET_GPIO >= 0 && RMII_RESET_GPIO <= 39, "RMII_RESET_GPIO out of range");
 
 static EventGroupHandle_t network_event_group;
 static const char *LOG_TAG = "net_task";
@@ -83,7 +81,7 @@ static void network_task(void *param)
     eth_mac_config_t mac_config = ETH_MAC_DEFAULT_CONFIG();
     eth_phy_config_t phy_config = ETH_PHY_DEFAULT_CONFIG();
     phy_config.phy_addr = 0;
-    phy_config.reset_gpio_num = RMII_RESET_GPIO;
+    phy_config.reset_gpio_num = -1; // Skip PHY reset
 
     eth_esp32_emac_config_t emac_config = ETH_ESP32_EMAC_DEFAULT_CONFIG();
     emac_config.smi_gpio.mdc_num = RMII_MDC_GPIO;

--- a/firmware/main/net_task.md
+++ b/firmware/main/net_task.md
@@ -1,6 +1,6 @@
 # Network Task
 
-Initialises the ESP32 Ethernet interface using a LAN87xx series PHY. The task configures the RMII pins via `smi_gpio`, installs the EMAC driver and assigns a static IP address using values generated in `config_autogen.h`.
+Initialises the ESP32 Ethernet interface using a LAN87xx series PHY. The task configures the RMII pins via `smi_gpio`, installs the EMAC driver and assigns a static IP address using values generated in `config_autogen.h`. The PHY reset line is unused so `reset_gpio_num` is set to `-1`.
 
 If driver installation fails, the task logs the error, frees any partially initialised resources and exits without setting `NETWORK_READY_BIT`, allowing the system to continue running without networking.
 


### PR DESCRIPTION
## Summary
- Skip PHY reset pin in net_task so driver does not toggle hardware
- Document that reset line is unused

## Testing
- `./run_all_tests.sh` *(fails: idf.py: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d6a665388322bf744abbc7dbbae3