### PR TITLE
Add PHY power pin control for Ethernet

### DIFF
--- a/firmware/main/net_task.md
+++ b/firmware/main/net_task.md
@@ -1,6 +1,6 @@
 # Network Task
 
-Initialises the ESP32 Ethernet interface using a LAN87xx series PHY. The task configures the RMII pins via `smi_gpio`, installs the EMAC driver and assigns a static IP address using values generated in `config_autogen.h`.
+Initialises the ESP32 Ethernet interface using a LAN87xx series PHY. The task configures the RMII pins via `smi_gpio`, powers the PHY by driving `RMII_POWER_GPIO` high, installs the EMAC driver and assigns a static IP address using values generated in `config_autogen.h`.
 
 If driver installation fails, the task logs the error, frees any partially initialised resources and exits without setting `NETWORK_READY_BIT`, allowing the system to continue running without networking.
 


### PR DESCRIPTION
## Summary
- define and validate RMII_POWER_GPIO for PHY power
- power up PHY before installing Ethernet driver
- document PHY power control in network task

## Testing
- `./run_all_tests.sh` *(fails: idf.py: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d6a1e34c8322925a2886c61cf2af