### PR TITLE
Test long frame transmission

### DIFF
--- a/firmware/test/README.md
+++ b/firmware/test/README.md
@@ -2,6 +2,8 @@
 
 Host-side unit tests for firmware modules. Unity is fetched during the CMake configure step using `FetchContent` from the official repository (tag `v2.5.2`). Tests read run counts and LED lengths from `config_autogen.h` so layouts with any number of runs can be exercised.
 
+The driver task tests include verification that frames exceeding the 64-symbol RMT hardware buffer are transmitted without truncation.
+
 ## Building and Running
 
 From the repository root:


### PR DESCRIPTION
## Summary
- ensure driver task unit tests cover frames >64 RMT symbols
- document long frame transmission coverage in test README

## Testing
- `cmake -S firmware/test -B firmware/test/build`
- `cmake --build firmware/test/build`
- `./firmware/test/build/test_rx_task`
- `./firmware/test/build/test_status_task`
- `./firmware/test/build/test_startup_sequence`
- `./firmware/test/build/test_driver_task`


------
https://chatgpt.com/codex/tasks/task_e_68b5bc5ba61c8322b73b0228bea8cff5