### PR TITLE
Replace deprecated delay with esp_rom_delay_us

### DIFF
--- a/firmware/main/driver_task.c
+++ b/firmware/main/driver_task.c
@@ -150,7 +150,7 @@ static void send_black(void)
                                      sizeof(rmt_symbol_word_t) * rmt_item_count[run_index],
                                      &TRANSMIT_CONFIG));
         wait_all_done_retry(rmt_channels[run_index]);
-        ets_delay_us(60);
+        esp_rom_delay_us(60);
     }
 }
 


### PR DESCRIPTION
## Summary
- avoid deprecated `ets_delay_us` by using `esp_rom_delay_us` for RMT transmission spacing

## Testing
- `pytest`
- `cmake -S firmware/test -B firmware/test/build`
- `cmake --build firmware/test/build`
- `./firmware/test/build/test_rx_task`
- `./firmware/test/build/test_status_task`
- `./firmware/test/build/test_driver_task`
- ❌ `idf.py test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f2c58e80832295a464431356dbb5