### PR TITLE
Add Ethernet reboot control

### DIFF
--- a/firmware/main/CMakeLists.txt
+++ b/firmware/main/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(
-    SRCS "app_main.c" "net_task.c" "rx_task.c" "driver_task.c" "status_task.c" "startup_sequence.c"
+    SRCS "app_main.c" "net_task.c" "rx_task.c" "driver_task.c" "status_task.c" "startup_sequence.c" "control_task.c"
     INCLUDE_DIRS "." "../include"
 )

--- a/firmware/main/README.md
+++ b/firmware/main/README.md
@@ -6,5 +6,6 @@ Application entry point and task startup. `app_main.c` creates FreeRTOS tasks fo
 - `rx_task.c` opens UDP sockets on `PORT_BASE + run_index` and assembles frame buffers keyed by `frame_id` (keeping only the current and next frames).
 - `driver_task.c` configures one RMT channel per run. It supports up to four runs of 400 LEDs each. On boot it waits one second, then flashes each run for one second before frame display begins.
 - `status_task.c` sends a heartbeat JSON every second to `SENDER_IP:STATUS_PORT`, reporting counters since the previous heartbeat.
+- `control_task.c` listens on `PORT_BASE + 100` for UDP packets and invokes `esp_restart()` when one is received, enabling remote reboot.
 
 Unit tests reside in `test/test_net_task.c` with `test/CMakeLists.txt` wiring them into the ESP-IDF `idf.py test` workflow.

--- a/firmware/main/app_main.c
+++ b/firmware/main/app_main.c
@@ -2,10 +2,12 @@
 #include "rx_task.h"
 #include "driver_task.h"
 #include "status_task.h"
+#include "control_task.h"
 
 void app_main(void)
 {
-    net_task_start();
+    EventGroupHandle_t network_event_group = net_task_start();
+    control_task_start(network_event_group);
     rx_task_start();
     driver_task_start();
     status_task_start();

--- a/firmware/main/control_task.c
+++ b/firmware/main/control_task.c
@@ -1,0 +1,44 @@
+#include "control_task.h"
+
+#include "config_autogen.h"
+#include <stdint.h>
+#include "net_task.h"
+#include "freertos/task.h"
+
+#include "esp_log.h"
+#include "esp_system.h"
+#include "lwip/sockets.h"
+
+static const char *LOG_TAG = "control_task";
+
+// Port for reboot command, offset from PORT_BASE to avoid run ports.
+static const uint16_t REBOOT_PORT = PORT_BASE + 100;
+
+static void control_task(void *param)
+{
+    EventGroupHandle_t network_event_group = (EventGroupHandle_t)param;
+    xEventGroupWaitBits(network_event_group, NETWORK_READY_BIT, pdFALSE, pdTRUE, portMAX_DELAY);
+
+    int socket_descriptor = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    struct sockaddr_in bind_address = {
+        .sin_family = AF_INET,
+        .sin_addr.s_addr = htonl(INADDR_ANY),
+        .sin_port = htons(REBOOT_PORT),
+    };
+    bind(socket_descriptor, (struct sockaddr *)&bind_address, sizeof(bind_address));
+
+    uint8_t data_buffer[1];
+    for (;;) {
+        ssize_t received_length = recvfrom(socket_descriptor, data_buffer, sizeof(data_buffer), 0, NULL, NULL);
+        if (received_length > 0) {
+            ESP_LOGI(LOG_TAG, "Reboot command received");
+            esp_restart();
+        }
+    }
+}
+
+void control_task_start(EventGroupHandle_t network_event_group)
+{
+    xTaskCreate(control_task, "control_task", 2048, (void *)network_event_group, 5, NULL);
+}
+

--- a/firmware/main/control_task.h
+++ b/firmware/main/control_task.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/event_groups.h"
+
+// Starts the control task which listens for reboot commands.
+void control_task_start(EventGroupHandle_t network_event_group);
+


### PR DESCRIPTION
## Summary
- allow device to reboot when receiving UDP packet on control port
- document control task

## Testing
- `python -m pip install -r tools/requirements.txt`
- `./run_all_tests.sh` *(fails: idf.py: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b68d0a42988322bb2a605d15658bce