### PR TITLE
docs: link root README to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 Utilities and firmware for the barn lights project.
 
+## Documentation
+
+Additional guides live in the [docs](docs) directory:
+
+- [ESP-IDF environment setup](docs/ESP-IDF.md)
+- [Flashing guide](docs/flash-guide.md)
+- [Project specification](docs/project-spec.md)
+- [UDP data format](docs/udp-data-format.md)
+
 ## Development
 
 ### Install Python dependencies:
@@ -40,7 +49,7 @@ To execute all test suites sequentially, run:
 ```
 python tools/gen_config.py --layout left.json
 ```
-2. Setup your ESP-IDF environment (see esp-idf.md). 
+2. Set up your ESP-IDF environment (see [ESP-IDF setup](docs/ESP-IDF.md)).
 3. Activate ESP-IDF and test it's in your session path:
 ```
 . ~/esp/esp-idf/export.sh
@@ -57,7 +66,7 @@ idf.py build
 
 ### Flash the ESP32 device
 
-See 'flash-guide.md'
+See [flash guide](docs/flash-guide.md)
 
 ### Convenience scripts
 

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -14,7 +14,7 @@ This directory contains the ESP-IDF based firmware for the Barn Lights system.
 ## Building
 
 First ensure you have generated your config using `./tools/gen_config.py` (see tools/readme.md).
-Ensure ESP-IDF is installed and in your PATH (see `./ESP-IDF.md`)
+Ensure ESP-IDF is installed and in your PATH (see [`../docs/ESP-IDF.md`](../docs/ESP-IDF.md))
 Navigate to this directory, then run:
 
 ```


### PR DESCRIPTION
## Summary
- add documentation section referencing ESP-IDF, flashing, spec, and UDP format docs
- update build and flash instructions to point at docs files
- fix firmware README to reference ESP-IDF docs in new location

## Testing
- `./run_all_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b70faea8a08322975049426606caec