### PR TITLE
Pin driver task to CPU1

### DIFF
--- a/firmware/main/README.md
+++ b/firmware/main/README.md
@@ -4,7 +4,7 @@ Application entry point and task startup. `app_main.c` creates FreeRTOS tasks fo
 
 - `net_task.c` initialises Ethernet and raises `NETWORK_READY_BIT` once the interface is ready.
 - `rx_task.c` opens UDP sockets on `PORT_BASE + run_index` and assembles frame buffers keyed by `frame_id` (keeping only the current and next frames).
-- `driver_task.c` configures one RMT channel per run. It supports up to four runs of 400 LEDs each. On boot it waits one second, then flashes each run for one second before frame display begins.
+- `driver_task.c` configures one RMT channel per run. It supports up to four runs of 400 LEDs each. On boot it waits one second, then flashes each run for one second before frame display begins. The task runs on CPU1 to avoid starving the CPU0 idle task.
 - `status_task.c` sends a heartbeat JSON every second to `SENDER_IP:STATUS_PORT`, reporting counters since the previous heartbeat.
 - `control_task.c` listens on `PORT_BASE + 100` for UDP packets and invokes `esp_restart()` when one is received, enabling remote reboot.
 

--- a/firmware/main/driver_task.c
+++ b/firmware/main/driver_task.c
@@ -238,6 +238,6 @@ static void driver_task(void *arg)
 
 void driver_task_start(void)
 {
-    xTaskCreate(driver_task, "driver_task", 4096, NULL, 5, NULL);
+    xTaskCreatePinnedToCore(driver_task, "driver_task", 4096, NULL, 5, NULL, 1);
 }
 


### PR DESCRIPTION
## Summary
- pin driver_task to CPU1 with xTaskCreatePinnedToCore to prevent IDLE0 watchdog starvation
- document CPU1 affinity in main README

## Testing
- `idf.py set-target esp32` *(fails: command not found)*
- `pip install espressif-idf` *(fails: no matching distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b555fcf88322adf8c03e11e0cc1d