### PR TITLE
Light first pixels during startup

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -7,7 +7,7 @@ This directory contains the ESP-IDF based firmware for the Barn Lights system.
 - **main/**: entry point containing `app_main.c`. It creates FreeRTOS tasks:
   - `network_task` handles networking.
   - `rx_task` processes inbound messages.
-  - `driver_task` drives the light output with one RMT channel per run and, in the absence of a sync manager, sends each run sequentially. Up to four runs of 400 LEDs each are supported. On startup it uses `startup_sequence.c` to flash each run for one second with RGB 218,170,52 after an initial one second delay.
+  - `driver_task` drives the light output with one RMT channel per run and, in the absence of a sync manager, sends each run sequentially. Up to four runs of 400 LEDs each are supported. On startup it uses `startup_sequence.c` to briefly flash the first few pixels of each run for one second with RGB 218,170,52 after an initial one second delay.
   - `status_task` emits a heartbeat JSON every second to `SENDER_IP:STATUS_PORT` containing runtime counters.
 - **components/**: custom components for the firmware (currently empty).
 

--- a/firmware/main/README.md
+++ b/firmware/main/README.md
@@ -4,7 +4,7 @@ Application entry point and task startup. `app_main.c` creates FreeRTOS tasks fo
 
 - `net_task.c` initialises Ethernet and raises `NETWORK_READY_BIT` once the interface is ready.
 - `rx_task.c` opens UDP sockets on `PORT_BASE + run_index` and assembles frame buffers keyed by `frame_id` (keeping only the current and next frames).
-- `driver_task.c` configures one RMT channel per run. It supports up to four runs of 400 LEDs each. On boot it waits one second, then flashes each run for one second before frame display begins.
+- `driver_task.c` configures one RMT channel per run. It supports up to four runs of 400 LEDs each. On boot it waits one second, then flashes the first few pixels of each run for one second before frame display begins.
 - `status_task.c` sends a heartbeat JSON every second to `SENDER_IP:STATUS_PORT`, reporting counters since the previous heartbeat.
 - `control_task.c` listens on `PORT_BASE + 100` for UDP packets and invokes `esp_restart()` when one is received, enabling remote reboot.
 


### PR DESCRIPTION
## Summary
- Reduce CPU load during startup by flashing only the first few LEDs in each run
- Reuse pre-zeroed RMT buffers when sending black frames
- Document new lightweight startup behaviour

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7b6189ad0832295d4c32a52a18d4d