### PR TITLE
Pin network and driver tasks to specific cores

### DIFF
--- a/firmware/main/driver_task.c
+++ b/firmware/main/driver_task.c
@@ -238,6 +238,6 @@ static void driver_task(void *arg)
 
 void driver_task_start(void)
 {
-    xTaskCreate(driver_task, "driver_task", 4096, NULL, 5, NULL);
+    xTaskCreatePinnedToCore(driver_task, "driver_task", 4096, NULL, 5, NULL, 1);
 }
 

--- a/firmware/main/net_task.c
+++ b/firmware/main/net_task.c
@@ -134,7 +134,7 @@ static void network_task(void *param)
 EventGroupHandle_t net_task_start(void)
 {
     network_event_group = xEventGroupCreate();
-    xTaskCreate(network_task, "net_task", 4096, NULL, 5, NULL);
+    xTaskCreatePinnedToCore(network_task, "net_task", 4096, NULL, 5, NULL, 0);
     return network_event_group;
 }
 

--- a/firmware/main/rx_task.c
+++ b/firmware/main/rx_task.c
@@ -163,7 +163,7 @@ void rx_task_start(void) {
     clear_slot(&frame_slots[1]);
 #ifndef UNIT_TEST
     for (unsigned int run = 0; run < RUN_COUNT; ++run) {
-        xTaskCreate(udp_listener_task, "rx_run", 4096, (void *)(uintptr_t)run, 5, NULL);
+        xTaskCreatePinnedToCore(udp_listener_task, "rx_run", 4096, (void *)(uintptr_t)run, 5, NULL, 0);
     }
 #endif
 }


### PR DESCRIPTION
## Summary
- Pin network setup, UDP listener, and driver tasks to explicit cores
- Assign networking and frame assembly tasks to core 0
- Run LED transmission task on core 1

## Testing
- `pytest`
- `cmake -S firmware/test -B firmware/test/build`
- `cmake --build firmware/test/build`
- `./firmware/test/build/test_rx_task`
- `./firmware/test/build/test_status_task`
- `./firmware/test/build/test_startup_sequence`
- `./firmware/test/build/test_driver_task`


------
https://chatgpt.com/codex/tasks/task_e_68b7bac08c8083229ff2e94a026ba780