### PR TITLE
Add startup delay before task initialization

### DIFF
--- a/firmware/main/README.md
+++ b/firmware/main/README.md
@@ -1,6 +1,6 @@
 # Main
 
-Application entry point and task startup. `app_main.c` creates FreeRTOS tasks for networking, UDP frame reception, driver control, and status reporting.
+Application entry point and task startup. `app_main.c` waits 1.5 seconds before creating FreeRTOS tasks for networking, UDP frame reception, driver control, and status reporting.
 
 - `net_task.c` initialises Ethernet and raises `NETWORK_READY_BIT` once the interface is ready.
 - `rx_task.c` opens UDP sockets on `PORT_BASE + run_index` and assembles frame buffers keyed by `frame_id` (keeping only the current and next frames).

--- a/firmware/main/app_main.c
+++ b/firmware/main/app_main.c
@@ -3,9 +3,12 @@
 #include "driver_task.h"
 #include "status_task.h"
 #include "control_task.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 
 void app_main(void)
 {
+    vTaskDelay(pdMS_TO_TICKS(1500));
     EventGroupHandle_t network_event_group = net_task_start();
     control_task_start(network_event_group);
     rx_task_start();


### PR DESCRIPTION
## Summary
- wait 1.5 seconds in `app_main` before starting FreeRTOS tasks to defer network and driver setup
- document the startup delay in main module README

## Testing
- `./tools/run_all_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b8cbc551188322a780fd61ff825d78