### PR TITLE
Fix frame supersession logic for RX task

### DIFF
--- a/firmware/main/rx_task.c
+++ b/firmware/main/rx_task.c
@@ -92,7 +92,7 @@ void rx_task_process_packet(unsigned int run_index, const uint8_t *data, size_t 
     } else if (frame_id == next_slot->frame_id) {
         target_slot = next_slot;
     } else if (frame_is_newer(frame_id, current_slot->frame_id)) {
-        if (next_slot->frame_id == 0 || frame_is_newer(next_slot->frame_id, frame_id)) {
+        if (next_slot->frame_id == 0 || frame_is_newer(frame_id, next_slot->frame_id)) {
             clear_slot(next_slot);
             next_slot->frame_id = frame_id;
             target_slot = next_slot;


### PR DESCRIPTION
## Summary
- ensure RX task replaces stale next_slot frames with newer incoming frames

## Testing
- `gcc -DUNIT_TEST -Iinclude -Imain /tmp/rx_task_test.c main/rx_task.c /tmp/status_stubs.c -o /tmp/rx_task_test`
- `/tmp/rx_task_test`
- `idf.py build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cc3d5a6483229c2a832ef11a1f0b