### PR TITLE
Use LED strip encoder and parallel RMT transmission

### DIFF
--- a/firmware/main/CMakeLists.txt
+++ b/firmware/main/CMakeLists.txt
@@ -1,4 +1,5 @@
 idf_component_register(
-    SRCS "app_main.c" "net_task.c" "rx_task.c" "driver_task.c" "status_task.c" "startup_sequence.c" "control_task.c"
+    SRCS "app_main.c" "net_task.c" "rx_task.c" "driver_task.c" "status_task.c" "startup_sequence.c" "control_task.c" "led_strip_encoder.c"
     INCLUDE_DIRS "." "../include"
+    REQUIRES driver
 )

--- a/firmware/main/README.md
+++ b/firmware/main/README.md
@@ -4,7 +4,7 @@ Application entry point and task startup. `app_main.c` creates FreeRTOS tasks fo
 
 - `net_task.c` initialises Ethernet and raises `NETWORK_READY_BIT` once the interface is ready.
 - `rx_task.c` opens UDP sockets on `PORT_BASE + run_index` and assembles frame buffers keyed by `frame_id` (keeping only the current and next frames).
-- `driver_task.c` configures one RMT channel per run. It supports up to four runs of 400 LEDs each. On boot it waits one second, then flashes each run for one second before frame display begins.
+- `driver_task.c` configures one RMT channel per run using the ESP-IDF LED strip encoder. Incoming RGB frames are reordered to GRB once before concurrent transmission, and the encoder emits the bytes verbatim. It supports up to four runs of 400 LEDs each. On boot it waits one second, then flashes each run for one second before frame display begins.
 - `status_task.c` sends a heartbeat JSON every second to `SENDER_IP:STATUS_PORT`, reporting counters since the previous heartbeat.
 - `control_task.c` listens on `PORT_BASE + 100` for UDP packets and invokes `esp_restart()` when one is received, enabling remote reboot.
 

--- a/firmware/main/driver_task.c
+++ b/firmware/main/driver_task.c
@@ -8,7 +8,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "driver/rmt_tx.h"
-#include "driver/rmt_encoder.h"
+#include "led_strip_encoder.h"
 #include "soc/soc_caps.h"
 #include "esp_log.h"
 #include "esp_rom_sys.h"
@@ -17,15 +17,6 @@
 #include <string.h>
 
 #define RMT_CLK_DIV 2
-#define RMT_TICKS_PER_BIT (80000000 / RMT_CLK_DIV / 800000)
-_Static_assert(RMT_TICKS_PER_BIT == 50, "Unexpected RMT bit timing");
-
-#define RMT_T0H_TICKS 16
-#define RMT_T0L_TICKS (RMT_TICKS_PER_BIT - RMT_T0H_TICKS)
-#define RMT_T1H_TICKS 32
-#define RMT_T1L_TICKS (RMT_TICKS_PER_BIT - RMT_T1H_TICKS)
-_Static_assert(RMT_T0H_TICKS + RMT_T0L_TICKS == RMT_TICKS_PER_BIT, "T0 timing");
-_Static_assert(RMT_T1H_TICKS + RMT_T1L_TICKS == RMT_TICKS_PER_BIT, "T1 timing");
 
 #define RUN0_GPIO 12
 #define RUN1_GPIO 14
@@ -62,10 +53,9 @@ _Static_assert(RUN3_GPIO >= 0 && RUN3_GPIO <= 39, "RUN3_GPIO out of range");
 #endif
 
 
-static rmt_symbol_word_t *rmt_items[RUN_COUNT];
-static size_t rmt_item_count[RUN_COUNT];
 static rmt_channel_handle_t rmt_channels[RUN_COUNT];
-static rmt_encoder_handle_t copy_encoder;
+static rmt_encoder_handle_t led_encoder;
+static uint8_t *grb_buffers[RUN_COUNT];
 static const rmt_transmit_config_t TRANSMIT_CONFIG = {
     .loop_count = 0,
 };
@@ -86,26 +76,18 @@ static esp_err_t wait_all_done_retry(rmt_channel_handle_t channel) {
     return ESP_ERR_TIMEOUT;
 }
 
-static inline void encode_run(unsigned int run_index, const uint8_t *rgb_data)
+// Convert RGB input to the GRB order expected by the LED strip. The LED strip
+// encoder transmits bytes verbatim, so this is the only reordering step.
+static inline void rgb_to_grb(unsigned int run_index, const uint8_t *rgb_data)
 {
-    rmt_symbol_word_t *items = rmt_items[run_index];
-    size_t item_index = 0;
+    uint8_t *grb_data = grb_buffers[run_index];
     for (unsigned int led_index = 0; led_index < LED_COUNT[run_index]; ++led_index) {
         uint8_t red = rgb_data[led_index * 3];
         uint8_t green = rgb_data[led_index * 3 + 1];
         uint8_t blue = rgb_data[led_index * 3 + 2];
-        uint8_t grb[3] = {green, red, blue};
-        for (int color = 0; color < 3; ++color) {
-            uint8_t value = grb[color];
-            for (int bit = 7; bit >= 0; --bit) {
-                bool bit_set = value & (1 << bit);
-                items[item_index].duration0 = bit_set ? RMT_T1H_TICKS : RMT_T0H_TICKS;
-                items[item_index].level0 = 1;
-                items[item_index].duration1 = bit_set ? RMT_T1L_TICKS : RMT_T0L_TICKS;
-                items[item_index].level1 = 0;
-                ++item_index;
-            }
-        }
+        grb_data[led_index * 3] = green;
+        grb_data[led_index * 3 + 1] = red;
+        grb_data[led_index * 3 + 2] = blue;
     }
 }
 
@@ -116,22 +98,25 @@ static bool frame_is_newer(uint32_t a, uint32_t b)
 
 static void send_frame(int slot_index)
 {
-    // Protect buffers while we read/encode
+    // Protect buffers while we read/convert
     rx_task_lock();
     for (unsigned int run = 0; run < RUN_COUNT; ++run) {
         const uint8_t *buffer = rx_task_get_run_buffer(slot_index, run);
-        encode_run(run, buffer); // fills rmt_items[run] / rmt_item_count[run]
+        rgb_to_grb(run, buffer);
     }
     rx_task_unlock();
 
-    // Transmit each run sequentially
+    // Start transmission on all runs
     for (unsigned int run = 0; run < RUN_COUNT; ++run) {
         ESP_ERROR_CHECK(rmt_transmit(
             rmt_channels[run],
-            copy_encoder,
-            rmt_items[run],
-            sizeof(rmt_symbol_word_t) * rmt_item_count[run],
+            led_encoder,
+            grb_buffers[run],
+            LED_COUNT[run] * 3,
             &TRANSMIT_CONFIG));
+    }
+    // Wait for completion of all runs
+    for (unsigned int run = 0; run < RUN_COUNT; ++run) {
         wait_all_done_retry(rmt_channels[run]);
     }
 }
@@ -140,15 +125,13 @@ static void send_frame(int slot_index)
 static void send_black(void)
 {
     for (unsigned int run_index = 0; run_index < RUN_COUNT; ++run_index) {
-        size_t led_count = LED_COUNT[run_index];
-        size_t byte_count = led_count * 3;
-        uint8_t *zero_buffer = (uint8_t *)calloc(byte_count, 1);
-        encode_run(run_index, zero_buffer);
-        free(zero_buffer);
-        ESP_ERROR_CHECK(rmt_transmit(rmt_channels[run_index], copy_encoder,
-                                     rmt_items[run_index],
-                                     sizeof(rmt_symbol_word_t) * rmt_item_count[run_index],
+        size_t byte_count = LED_COUNT[run_index] * 3;
+        memset(grb_buffers[run_index], 0, byte_count);
+        ESP_ERROR_CHECK(rmt_transmit(rmt_channels[run_index], led_encoder,
+                                     grb_buffers[run_index], byte_count,
                                      &TRANSMIT_CONFIG));
+    }
+    for (unsigned int run_index = 0; run_index < RUN_COUNT; ++run_index) {
         wait_all_done_retry(rmt_channels[run_index]);
         esp_rom_delay_us(60);
     }
@@ -157,19 +140,15 @@ static void send_black(void)
 static void flash_run(unsigned int run_index,
                       uint8_t red, uint8_t green, uint8_t blue)
 {
-    size_t led_count = LED_COUNT[run_index];
-    size_t byte_count = led_count * 3;
-    uint8_t *rgb_buffer = (uint8_t *)malloc(byte_count);
-    for (unsigned int led = 0; led < led_count; ++led) {
-        rgb_buffer[led * 3] = red;
-        rgb_buffer[led * 3 + 1] = green;
-        rgb_buffer[led * 3 + 2] = blue;
+    size_t byte_count = LED_COUNT[run_index] * 3;
+    for (unsigned int led = 0; led < LED_COUNT[run_index]; ++led) {
+        uint8_t *grb = &grb_buffers[run_index][led * 3];
+        grb[0] = green;
+        grb[1] = red;
+        grb[2] = blue;
     }
-    encode_run(run_index, rgb_buffer);
-    free(rgb_buffer);
-    ESP_ERROR_CHECK(rmt_transmit(rmt_channels[run_index], copy_encoder,
-                                 rmt_items[run_index],
-                                 sizeof(rmt_symbol_word_t) * rmt_item_count[run_index],
+    ESP_ERROR_CHECK(rmt_transmit(rmt_channels[run_index], led_encoder,
+                                 grb_buffers[run_index], byte_count,
                                  &TRANSMIT_CONFIG));
     wait_all_done_retry(rmt_channels[run_index]);
 }
@@ -181,8 +160,10 @@ static void delay_ms(uint32_t ms)
 
 static void driver_task(void *arg)
 {
-    rmt_copy_encoder_config_t copy_config = {};
-    ESP_ERROR_CHECK(rmt_new_copy_encoder(&copy_config, &copy_encoder));
+    led_strip_encoder_config_t encoder_config = {
+        .resolution = 80000000 / RMT_CLK_DIV,
+    };
+    ESP_ERROR_CHECK(rmt_new_led_strip_encoder(&encoder_config, &led_encoder));
 
     for (unsigned int run = 0; run < RUN_COUNT; ++run) {
         rmt_tx_channel_config_t channel_config = {
@@ -194,9 +175,8 @@ static void driver_task(void *arg)
         };
         ESP_ERROR_CHECK(rmt_new_tx_channel(&channel_config, &rmt_channels[run]));
         ESP_ERROR_CHECK(rmt_enable(rmt_channels[run]));
-        rmt_item_count[run] = LED_COUNT[run] * 24;
-        rmt_items[run] = (rmt_symbol_word_t *)malloc(sizeof(rmt_symbol_word_t) * rmt_item_count[run]);
-        memset(rmt_items[run], 0, sizeof(rmt_symbol_word_t) * rmt_item_count[run]);
+        grb_buffers[run] = (uint8_t *)malloc(LED_COUNT[run] * 3);
+        memset(grb_buffers[run], 0, LED_COUNT[run] * 3);
     }
 
     send_black();

--- a/firmware/main/led_strip_encoder.c
+++ b/firmware/main/led_strip_encoder.c
@@ -1,0 +1,124 @@
+/*
+ * SPDX-FileCopyrightText: 2021-2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "esp_check.h"
+#include "led_strip_encoder.h"
+
+static const char *TAG = "led_encoder";
+
+typedef struct {
+    rmt_encoder_t base;
+    rmt_encoder_t *bytes_encoder;
+    rmt_encoder_t *copy_encoder;
+    int state;
+    rmt_symbol_word_t reset_code;
+} rmt_led_strip_encoder_t;
+
+static size_t rmt_encode_led_strip(rmt_encoder_t *encoder, rmt_channel_handle_t channel, const void *primary_data, size_t data_size, rmt_encode_state_t *ret_state)
+{
+    rmt_led_strip_encoder_t *led_encoder = __containerof(encoder, rmt_led_strip_encoder_t, base);
+    rmt_encoder_handle_t bytes_encoder = led_encoder->bytes_encoder;
+    rmt_encoder_handle_t copy_encoder = led_encoder->copy_encoder;
+    rmt_encode_state_t session_state = RMT_ENCODING_RESET;
+    rmt_encode_state_t state = RMT_ENCODING_RESET;
+    size_t encoded_symbols = 0;
+    switch (led_encoder->state) {
+    case 0: // send RGB data
+        encoded_symbols += bytes_encoder->encode(bytes_encoder, channel, primary_data, data_size, &session_state);
+        if (session_state & RMT_ENCODING_COMPLETE) {
+            led_encoder->state = 1; // switch to next state when current encoding session finished
+        }
+        if (session_state & RMT_ENCODING_MEM_FULL) {
+            state |= RMT_ENCODING_MEM_FULL;
+            goto out; // yield if there's no free space for encoding artifacts
+        }
+    // fall-through
+    case 1: // send reset code
+        encoded_symbols += copy_encoder->encode(copy_encoder, channel, &led_encoder->reset_code,
+                                                sizeof(led_encoder->reset_code), &session_state);
+        if (session_state & RMT_ENCODING_COMPLETE) {
+            led_encoder->state = RMT_ENCODING_RESET; // back to the initial encoding session
+            state |= RMT_ENCODING_COMPLETE;
+        }
+        if (session_state & RMT_ENCODING_MEM_FULL) {
+            state |= RMT_ENCODING_MEM_FULL;
+            goto out; // yield if there's no free space for encoding artifacts
+        }
+    }
+out:
+    *ret_state = state;
+    return encoded_symbols;
+}
+
+static esp_err_t rmt_del_led_strip_encoder(rmt_encoder_t *encoder)
+{
+    rmt_led_strip_encoder_t *led_encoder = __containerof(encoder, rmt_led_strip_encoder_t, base);
+    rmt_del_encoder(led_encoder->bytes_encoder);
+    rmt_del_encoder(led_encoder->copy_encoder);
+    free(led_encoder);
+    return ESP_OK;
+}
+
+static esp_err_t rmt_led_strip_encoder_reset(rmt_encoder_t *encoder)
+{
+    rmt_led_strip_encoder_t *led_encoder = __containerof(encoder, rmt_led_strip_encoder_t, base);
+    rmt_encoder_reset(led_encoder->bytes_encoder);
+    rmt_encoder_reset(led_encoder->copy_encoder);
+    led_encoder->state = RMT_ENCODING_RESET;
+    return ESP_OK;
+}
+
+esp_err_t rmt_new_led_strip_encoder(const led_strip_encoder_config_t *config, rmt_encoder_handle_t *ret_encoder)
+{
+    esp_err_t ret = ESP_OK;
+    rmt_led_strip_encoder_t *led_encoder = NULL;
+    ESP_GOTO_ON_FALSE(config && ret_encoder, ESP_ERR_INVALID_ARG, err, TAG, "invalid argument");
+    led_encoder = calloc(1, sizeof(rmt_led_strip_encoder_t));
+    ESP_GOTO_ON_FALSE(led_encoder, ESP_ERR_NO_MEM, err, TAG, "no mem for led strip encoder");
+    led_encoder->base.encode = rmt_encode_led_strip;
+    led_encoder->base.del = rmt_del_led_strip_encoder;
+    led_encoder->base.reset = rmt_led_strip_encoder_reset;
+    // different led strip might have its own timing requirements, following parameter is for WS2812
+    rmt_bytes_encoder_config_t bytes_encoder_config = {
+        .bit0 = {
+            .level0 = 1,
+            .duration0 = 0.3 * config->resolution / 1000000, // T0H=0.3us
+            .level1 = 0,
+            .duration1 = 0.9 * config->resolution / 1000000, // T0L=0.9us
+        },
+        .bit1 = {
+            .level0 = 1,
+            .duration0 = 0.9 * config->resolution / 1000000, // T1H=0.9us
+            .level1 = 0,
+            .duration1 = 0.3 * config->resolution / 1000000, // T1L=0.3us
+        },
+        .flags.msb_first = 1 // WS2812 transfer bit order: G7...G0R7...R0B7...B0
+    };
+    ESP_GOTO_ON_ERROR(rmt_new_bytes_encoder(&bytes_encoder_config, &led_encoder->bytes_encoder), err, TAG, "create bytes encoder failed");
+    rmt_copy_encoder_config_t copy_encoder_config = {};
+    ESP_GOTO_ON_ERROR(rmt_new_copy_encoder(&copy_encoder_config, &led_encoder->copy_encoder), err, TAG, "create copy encoder failed");
+
+    uint32_t reset_ticks = config->resolution / 1000000 * 50 / 2; // reset code duration defaults to 50us
+    led_encoder->reset_code = (rmt_symbol_word_t) {
+        .level0 = 0,
+        .duration0 = reset_ticks,
+        .level1 = 0,
+        .duration1 = reset_ticks,
+    };
+    *ret_encoder = &led_encoder->base;
+    return ESP_OK;
+err:
+    if (led_encoder) {
+        if (led_encoder->bytes_encoder) {
+            rmt_del_encoder(led_encoder->bytes_encoder);
+        }
+        if (led_encoder->copy_encoder) {
+            rmt_del_encoder(led_encoder->copy_encoder);
+        }
+        free(led_encoder);
+    }
+    return ret;
+}

--- a/firmware/main/led_strip_encoder.h
+++ b/firmware/main/led_strip_encoder.h
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: 2021-2022 Espressif Systems (Shanghai) CO LTD
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#pragma once
+
+#include <stdint.h>
+#include "driver/rmt_encoder.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Type of led strip encoder configuration
+ */
+typedef struct {
+    uint32_t resolution; /*!< Encoder resolution, in Hz */
+} led_strip_encoder_config_t;
+
+/**
+ * @brief Create RMT encoder for encoding LED strip pixels into RMT symbols
+ *
+ * @param[in] config Encoder configuration
+ * @param[out] ret_encoder Returned encoder handle
+ * @return
+ *      - ESP_ERR_INVALID_ARG for any invalid arguments
+ *      - ESP_ERR_NO_MEM out of memory when creating led strip encoder
+ *      - ESP_OK if creating encoder successfully
+ */
+esp_err_t rmt_new_led_strip_encoder(const led_strip_encoder_config_t *config, rmt_encoder_handle_t *ret_encoder);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
## Summary
- replace custom bit encoding with ESP-IDF's LED strip encoder and GRB buffers
- launch RMT transmit on all runs before waiting for completion
- include LED strip encoder source in build
- clarify GRB conversion path and declare driver component dependency

## Testing
- `idf.py --version` *(fails: No module named 'esp_idf_monitor')*
- `./esp-idf/install.sh esp32` *(fails: libusb-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b8ce08b6a08322b05f82385e17a621