### PR TITLE
Add restart-aware frame comparison utility

### DIFF
--- a/firmware/main/README.md
+++ b/firmware/main/README.md
@@ -7,5 +7,6 @@ Application entry point and task startup. `app_main.c` creates FreeRTOS tasks fo
 - `driver_task.c` configures one RMT channel per run. It supports up to four runs of 400 LEDs each. On boot it waits one second, then flashes each run for one second before frame display begins.
 - `status_task.c` sends a heartbeat JSON every second to `SENDER_IP:STATUS_PORT`, reporting counters since the previous heartbeat.
 - `control_task.c` listens on `PORT_BASE + 100` for UDP packets and invokes `esp_restart()` when one is received, enabling remote reboot.
+- `frame_utils.h` provides `frame_is_newer_with_reset` which treats a large backward jump in `frame_id` as a transmitter restart.
 
 Unit tests reside in `test/test_net_task.c` with `test/CMakeLists.txt` wiring them into the ESP-IDF `idf.py test` workflow.

--- a/firmware/main/driver_task.c
+++ b/firmware/main/driver_task.c
@@ -4,6 +4,7 @@
 #include "rx_task.h"
 #include "status_task.h"
 #include "startup_sequence.h"
+#include "frame_utils.h"
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -107,11 +108,6 @@ static inline void encode_run(unsigned int run_index, const uint8_t *rgb_data)
             }
         }
     }
-}
-
-static bool frame_is_newer(uint32_t a, uint32_t b)
-{
-    return (int32_t)(a - b) > 0;
 }
 
 static void send_frame(int slot_index)
@@ -231,7 +227,7 @@ static void driver_task(void *arg)
         rx_task_lock();
         for (int slot = 0; slot < 2; ++slot) {
             uint32_t frame_id = rx_task_get_frame_id(slot);
-            if (frame_is_newer(frame_id, selected_id)) {
+            if (frame_is_newer_with_reset(frame_id, selected_id, FRAME_RESET_THRESHOLD)) {
                 bool frame_complete = true;
                 for (unsigned int run = 0; run < RUN_COUNT; ++run) {
                     if (!rx_task_run_received(slot, run)) {

--- a/firmware/main/frame_utils.h
+++ b/firmware/main/frame_utils.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+// Maximum backward difference to treat as a transmitter restart.
+// Differences greater than this are considered a reset and thus newer.
+#define FRAME_RESET_THRESHOLD 1000U
+
+static inline bool frame_is_newer_with_reset(uint32_t candidate_frame_id,
+                                             uint32_t reference_frame_id,
+                                             uint32_t reset_threshold)
+{
+    int32_t diff = (int32_t)(candidate_frame_id - reference_frame_id);
+    return diff > 0 || diff < -(int32_t)reset_threshold;
+}
+

--- a/firmware/main/rx_task.c
+++ b/firmware/main/rx_task.c
@@ -2,6 +2,7 @@
 
 #include "config_autogen.h"
 #include "status_task.h"
+#include "frame_utils.h"
 
 #include <stdbool.h>
 #include <stdlib.h>
@@ -46,10 +47,6 @@ void rx_task_unlock(void) {
     xSemaphoreGiveRecursive(frame_mutex);
 }
 
-static bool frame_is_newer(uint32_t a, uint32_t b) {
-    return (int32_t)(a - b) > 0;
-}
-
 static void allocate_buffers(void) {
     for (int slot = 0; slot < 2; ++slot) {
         frame_buffers[slot] = (uint8_t **)malloc(sizeof(uint8_t *) * RUN_COUNT);
@@ -91,8 +88,9 @@ void rx_task_process_packet(unsigned int run_index, const uint8_t *data, size_t 
         target_slot = current_slot;
     } else if (frame_id == next_slot->frame_id) {
         target_slot = next_slot;
-    } else if (frame_is_newer(frame_id, current_slot->frame_id)) {
-        if (next_slot->frame_id == 0 || frame_is_newer(next_slot->frame_id, frame_id)) {
+    } else if (frame_is_newer_with_reset(frame_id, current_slot->frame_id, FRAME_RESET_THRESHOLD)) {
+        if (next_slot->frame_id == 0 ||
+            frame_is_newer_with_reset(next_slot->frame_id, frame_id, FRAME_RESET_THRESHOLD)) {
             clear_slot(next_slot);
             next_slot->frame_id = frame_id;
             target_slot = next_slot;

--- a/firmware/test/CMakeLists.txt
+++ b/firmware/test/CMakeLists.txt
@@ -49,3 +49,10 @@ add_executable(test_driver_task
 
 target_link_libraries(test_driver_task unity)
 
+add_executable(test_frame_utils
+    test_frame_utils.c
+)
+
+target_include_directories(test_frame_utils PRIVATE ../main)
+target_link_libraries(test_frame_utils unity)
+

--- a/firmware/test/README.md
+++ b/firmware/test/README.md
@@ -14,5 +14,7 @@ cmake --build firmware/test/build
 ./firmware/test/build/test_rx_task
 ./firmware/test/build/test_status_task
 ./firmware/test/build/test_driver_task
+./firmware/test/build/test_startup_sequence
+./firmware/test/build/test_frame_utils
 ```
 

--- a/firmware/test/test_frame_utils.c
+++ b/firmware/test/test_frame_utils.c
@@ -1,0 +1,24 @@
+#include "unity.h"
+#include "frame_utils.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_detects_newer_frame(void) {
+    TEST_ASSERT_TRUE(frame_is_newer_with_reset(2, 1, FRAME_RESET_THRESHOLD));
+    TEST_ASSERT_FALSE(frame_is_newer_with_reset(1, 2, FRAME_RESET_THRESHOLD));
+}
+
+void test_detects_restart(void) {
+    // Large backward jump indicates transmitter restart.
+    TEST_ASSERT_TRUE(frame_is_newer_with_reset(1, 5000, FRAME_RESET_THRESHOLD));
+    // Small backward jump treated as out-of-order and ignored.
+    TEST_ASSERT_FALSE(frame_is_newer_with_reset(4990, 5000, FRAME_RESET_THRESHOLD));
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_detects_newer_frame);
+    RUN_TEST(test_detects_restart);
+    return UNITY_END();
+}

--- a/firmware/test/test_rx_task.c
+++ b/firmware/test/test_rx_task.c
@@ -76,10 +76,31 @@ void test_frame_slots_only_keep_current_and_next(void) {
     free(packet);
 }
 
+void test_frame_id_restart_handled(void) {
+    size_t len = 4 + LED_COUNT[0] * 3;
+    uint8_t *packet = (uint8_t *)malloc(len);
+    memset(packet, 0, len);
+
+    // Establish a high frame id as the current frame.
+    packet[2] = 0x13; // 5000 >> 8
+    packet[3] = 0x88; // 5000 & 0xFF
+    rx_task_process_packet(0, packet, len);
+    TEST_ASSERT_EQUAL_UINT32(5000, rx_task_get_frame_id(0));
+
+    // Simulate sender restart with frame id 1.
+    memset(packet, 0, len);
+    packet[3] = 1;
+    rx_task_process_packet(0, packet, len);
+    TEST_ASSERT_EQUAL_UINT32(1, rx_task_get_frame_id(1));
+
+    free(packet);
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_invalid_length_ignored);
     RUN_TEST(test_copy_payload_without_reordering);
     RUN_TEST(test_frame_slots_only_keep_current_and_next);
+    RUN_TEST(test_frame_id_restart_handled);
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary
- add `frame_utils.h` with `frame_is_newer_with_reset` to detect restarts
- refactor `rx_task` and `driver_task` to use shared frame comparison
- cover restart scenarios in unit tests and update documentation

## Testing
- `cmake -S firmware/test -B firmware/test/build`
- `cmake --build firmware/test/build`
- `./firmware/test/build/test_rx_task`
- `./firmware/test/build/test_status_task`
- `./firmware/test/build/test_driver_task`
- `./firmware/test/build/test_startup_sequence`
- `./firmware/test/build/test_frame_utils`


------
https://chatgpt.com/codex/tasks/task_e_68bc905e177c8322a535b0a8706b4265