### PR TITLE
Report SRAM statistics in heartbeat

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -8,7 +8,7 @@ This directory contains the ESP-IDF based firmware for the Barn Lights system.
   - `network_task` handles networking.
   - `rx_task` processes inbound messages.
   - `driver_task` drives the light output with one RMT channel per run and, in the absence of a sync manager, sends each run sequentially. Up to four runs of 400 LEDs each are supported. On startup it uses `startup_sequence.c` to briefly flash the first few pixels of each run for one second with RGB 218,170,52 after an initial one second delay.
-  - `status_task` emits a heartbeat JSON every second to `SENDER_IP:STATUS_PORT` containing runtime counters.
+  - `status_task` emits a heartbeat JSON every second to `SENDER_IP:STATUS_PORT` containing runtime counters and SRAM statistics.
 - **components/**: custom components for the firmware (currently empty).
 
 ## Building

--- a/firmware/main/README.md
+++ b/firmware/main/README.md
@@ -5,7 +5,7 @@ Application entry point and task startup. `app_main.c` creates FreeRTOS tasks fo
 - `net_task.c` initialises Ethernet and raises `NETWORK_READY_BIT` once the interface is ready.
 - `rx_task.c` opens UDP sockets on `PORT_BASE + run_index` and assembles frame buffers keyed by `frame_id` (keeping only the current and next frames).
 - `driver_task.c` configures one RMT channel per run. It supports up to four runs of 400 LEDs each. On boot it waits one second, then flashes each run for one second before frame display begins.
-- `status_task.c` sends a heartbeat JSON every second to `SENDER_IP:STATUS_PORT`, reporting counters since the previous heartbeat.
+- `status_task.c` sends a heartbeat JSON every second to `SENDER_IP:STATUS_PORT`, reporting counters since the previous heartbeat along with SRAM usage metrics.
 - `control_task.c` listens on `PORT_BASE + 100` for UDP packets and invokes `esp_restart()` when one is received, enabling remote reboot.
 
 Unit tests reside in `test/test_net_task.c` with `test/CMakeLists.txt` wiring them into the ESP-IDF `idf.py test` workflow.

--- a/firmware/main/status_task.c
+++ b/firmware/main/status_task.c
@@ -35,22 +35,26 @@ void status_task_reset_counters(void) {
     dropped_count = 0;
 }
 
-size_t status_task_format_json(char *buffer, size_t buffer_len, uint32_t uptime_ms, bool link) {
+size_t status_task_format_json(char *buffer, size_t buffer_len, uint32_t uptime_ms, bool link,
+                               uint32_t free_heap_total, uint32_t free_heap_internal,
+                               uint32_t largest_free_block) {
     char ip_str[16];
     snprintf(ip_str, sizeof(ip_str), "%u.%u.%u.%u", STATIC_IP_ADDR0, STATIC_IP_ADDR1, STATIC_IP_ADDR2, STATIC_IP_ADDR3);
     size_t offset = 0;
     offset += snprintf(buffer + offset, buffer_len - offset,
                        "{\"id\":\"%s\",\"ip\":\"%s\",\"uptime_ms\":%" PRIu32 ",\"link\":%s,\"runs\":%u,\"leds\":[",
                        SIDE_ID_STR, ip_str, uptime_ms, link ? "true" : "false", RUN_COUNT);
-    for (unsigned int i = 0; i < RUN_COUNT; ++i) {
-        offset += snprintf(buffer + offset, buffer_len - offset, "%u", LED_COUNT[i]);
-        if (i + 1 < RUN_COUNT) {
+    for (unsigned int run_index = 0; run_index < RUN_COUNT; ++run_index) {
+        offset += snprintf(buffer + offset, buffer_len - offset, "%u", LED_COUNT[run_index]);
+        if (run_index + 1 < RUN_COUNT) {
             offset += snprintf(buffer + offset, buffer_len - offset, ",");
         }
     }
     offset += snprintf(buffer + offset, buffer_len - offset,
-                       "],\"rx_frames\":%" PRIu32 ",\"complete\":%" PRIu32 ",\"applied\":%" PRIu32 ",\"dropped_frames\":%" PRIu32 ",\"errors\":[]}",
-                       rx_frames_count, complete_count, applied_count, dropped_count);
+                       "],\"rx_frames\":%" PRIu32 ",\"complete\":%" PRIu32 ",\"applied\":%" PRIu32 ",\"dropped_frames\":%" PRIu32 ","
+                       "\"mem_free_total\":%" PRIu32 ",\"mem_free_internal\":%" PRIu32 ",\"mem_largest_block\":%" PRIu32 ",\"errors\":[]}",
+                       rx_frames_count, complete_count, applied_count, dropped_count,
+                       free_heap_total, free_heap_internal, largest_free_block);
     return offset;
 }
 
@@ -60,6 +64,7 @@ size_t status_task_format_json(char *buffer, size_t buffer_len, uint32_t uptime_
 #include "lwip/inet.h"
 #include "lwip/sockets.h"
 #include "esp_timer.h"
+#include "esp_heap_caps.h"
 
 static void status_task(void *param) {
     int sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
@@ -74,7 +79,11 @@ static void status_task(void *param) {
     char json[256];
     for (;;) {
         uint32_t uptime_ms = (uint32_t)(esp_timer_get_time() / 1000);
-        status_task_format_json(json, sizeof(json), uptime_ms, true);
+        uint32_t free_heap_total = (uint32_t)esp_get_free_heap_size();
+        uint32_t free_heap_internal = (uint32_t)heap_caps_get_free_size(MALLOC_CAP_INTERNAL);
+        uint32_t largest_free_block = (uint32_t)heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL);
+        status_task_format_json(json, sizeof(json), uptime_ms, true, free_heap_total,
+                               free_heap_internal, largest_free_block);
         sendto(sock, json, strlen(json), 0, (struct sockaddr *)&dest, sizeof(dest));
         status_task_reset_counters();
         vTaskDelay(pdMS_TO_TICKS(1000));

--- a/firmware/main/status_task.h
+++ b/firmware/main/status_task.h
@@ -12,4 +12,6 @@ void status_task_increment_applied(void);
 void status_task_increment_drops(void);
 void status_task_reset_counters(void);
 
-size_t status_task_format_json(char *buffer, size_t buffer_len, uint32_t uptime_ms, bool link);
+size_t status_task_format_json(char *buffer, size_t buffer_len, uint32_t uptime_ms, bool link,
+                               uint32_t free_heap_total, uint32_t free_heap_internal,
+                               uint32_t largest_free_block);

--- a/firmware/test/test_status_task.c
+++ b/firmware/test/test_status_task.c
@@ -13,8 +13,14 @@ void test_format_json(void) {
     status_task_increment_applied();
     status_task_increment_drops();
 
+    const uint32_t expected_free_total = 111;
+    const uint32_t expected_free_internal = 222;
+    const uint32_t expected_largest_block = 333;
+
     char json_buffer[256];
-    size_t json_length = status_task_format_json(json_buffer, sizeof(json_buffer), 123, true);
+    size_t json_length = status_task_format_json(json_buffer, sizeof(json_buffer), 123, true,
+                                                 expected_free_total, expected_free_internal,
+                                                 expected_largest_block);
 
     const char *side_str = SIDE_ID == 0 ? "LEFT" : "RIGHT";
     char expected[256];
@@ -22,14 +28,16 @@ void test_format_json(void) {
     offset += snprintf(expected + offset, sizeof(expected) - offset,
                        "{\"id\":\"%s\",\"ip\":\"%u.%u.%u.%u\",\"uptime_ms\":123,\"link\":true,\"runs\":%u,\"leds\":[",
                        side_str, STATIC_IP_ADDR0, STATIC_IP_ADDR1, STATIC_IP_ADDR2, STATIC_IP_ADDR3, RUN_COUNT);
-    for (unsigned int i = 0; i < RUN_COUNT; ++i) {
-        offset += snprintf(expected + offset, sizeof(expected) - offset, "%u", LED_COUNT[i]);
-        if (i + 1 < RUN_COUNT) {
+    for (unsigned int run_index = 0; run_index < RUN_COUNT; ++run_index) {
+        offset += snprintf(expected + offset, sizeof(expected) - offset, "%u", LED_COUNT[run_index]);
+        if (run_index + 1 < RUN_COUNT) {
             offset += snprintf(expected + offset, sizeof(expected) - offset, ",");
         }
     }
     offset += snprintf(expected + offset, sizeof(expected) - offset,
-                       "],\"rx_frames\":1,\"complete\":1,\"applied\":1,\"dropped_frames\":1,\"errors\":[]}");
+                       "],\"rx_frames\":1,\"complete\":1,\"applied\":1,\"dropped_frames\":1,"
+                       "\"mem_free_total\":%u,\"mem_free_internal\":%u,\"mem_largest_block\":%u,\"errors\":[]}",
+                       expected_free_total, expected_free_internal, expected_largest_block);
 
     TEST_ASSERT_EQUAL(offset, json_length);
     TEST_ASSERT_EQUAL_STRING(expected, json_buffer);

--- a/tools/heartbeat_monitor.py
+++ b/tools/heartbeat_monitor.py
@@ -16,7 +16,8 @@ def render_table(last_data: Dict[str, Optional[dict]], last_seen: Dict[str, Opti
     """Print a table of the most recent heartbeat data."""
     header = (
         f"{'Device':<6} {'IP':<15} {'Uptime(ms)':<12} {'Link':<5} "
-        f"{'Rx':<10} {'Complete':<10} {'Applied':<10} {'Dropped':<10} {'Last Seen':<10}"
+        f"{'Rx':<10} {'Complete':<10} {'Applied':<10} {'Dropped':<10} "
+        f"{'FreeTot':<10} {'FreeInt':<10} {'Largest':<10} {'Last Seen':<10}"
     )
     print(header)
     print("-" * len(header))
@@ -26,7 +27,8 @@ def render_table(last_data: Dict[str, Optional[dict]], last_seen: Dict[str, Opti
         if heartbeat is None:
             row = (
                 f"{device_id:<6} {'--':<15} {'--':<12} {'--':<5} "
-                f"{'--':<10} {'--':<10} {'--':<10} {'--':<10} {'--':<10}"
+                f"{'--':<10} {'--':<10} {'--':<10} {'--':<10} "
+                f"{'--':<10} {'--':<10} {'--':<10} {'--':<10}"
             )
         else:
             seconds_since = current_time - (last_seen.get(device_id) or current_time)
@@ -34,7 +36,8 @@ def render_table(last_data: Dict[str, Optional[dict]], last_seen: Dict[str, Opti
                 f"{device_id:<6} {heartbeat.get('ip', '--'):<15} {heartbeat.get('uptime_ms', '--'):<12} "
                 f"{str(heartbeat.get('link', '--')):<5} {heartbeat.get('rx_frames', '--'):<10} "
                 f"{heartbeat.get('complete', '--'):<10} {heartbeat.get('applied', '--'):<10} "
-                f"{heartbeat.get('dropped_frames', '--'):<10} {seconds_since:>.1f}s"
+                f"{heartbeat.get('dropped_frames', '--'):<10} {heartbeat.get('mem_free_total', '--'):<10} "
+                f"{heartbeat.get('mem_free_internal', '--'):<10} {heartbeat.get('mem_largest_block', '--'):<10} {seconds_since:>.1f}s"
             )
         print(row)
 

--- a/tools/readme.md
+++ b/tools/readme.md
@@ -2,7 +2,7 @@
 
 The `gen_config.py` script reads a layout JSON file and writes `firmware/include/config_autogen.h` with constants used by the firmware. Layout files must include `static_ip`, `static_netmask`, and `static_gateway` fields, each listing four integer octets. These values become the `STATIC_IP_ADDR*`, `STATIC_NETMASK_ADDR*`, and `STATIC_GW_ADDR*` macros in the generated header. `port_base` and `gateway_telemetry_port` fields map to `PORT_BASE` and `STATUS_PORT` macros. Up to four LED runs are supported, with a maximum of 400 LEDs per run; `RUN_COUNT` and the `LED_COUNT` array are derived from the provided runs.
 
-The `heartbeat_monitor.py` script listens for heartbeat telemetry from the left and right wall controllers and prints a table summarizing the latest data. Missing signals are tolerated so monitoring continues even if only one device is active.
+The `heartbeat_monitor.py` script listens for heartbeat telemetry from the left and right wall controllers and prints a table summarizing the latest data, including SRAM statistics. Missing signals are tolerated so monitoring continues even if only one device is active.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- include SRAM usage metrics in heartbeat JSON
- display memory statistics in heartbeat monitor

## Testing
- `pytest`
- `cmake -S firmware/test -B firmware/test/build`
- `cmake --build firmware/test/build`
- `./firmware/test/build/test_rx_task`
- `./firmware/test/build/test_status_task`
- `./firmware/test/build/test_driver_task`
- `./firmware/test/build/test_startup_sequence`


------
https://chatgpt.com/codex/tasks/task_e_68c391f919288322952273bb0052b5e6